### PR TITLE
Transform the FileWriter output to a more generic one

### DIFF
--- a/output/all.go
+++ b/output/all.go
@@ -8,7 +8,7 @@ import (
 func AllOutputs() []baker.OutputDesc {
 	return []baker.OutputDesc{
 		DynamoDBDesc,
-		FilesDesc,
+		FileWriterDesc,
 		NopDesc,
 		OpLogDesc,
 		WebSocketDesc,

--- a/output/bench_test.go
+++ b/output/bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkFilesOutput(b *testing.B) {
 
 	c := baker.Components{
 		Inputs:  []baker.InputDesc{inputtest.RandomDesc},
-		Outputs: []baker.OutputDesc{FilesDesc},
+		Outputs: []baker.OutputDesc{FileWriterDesc},
 	}
 
 	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), c)


### PR DESCRIPTION
#### :question: What

Remove AWS specific stuff from the filewriter, changing its name