### PR TITLE
upload: disable S3 uploader for now

### DIFF
--- a/upload/all.go
+++ b/upload/all.go
@@ -4,5 +4,6 @@ import "github.com/AdRoll/baker"
 
 // All is the list of all aws uploads.
 var All = []baker.UploadDesc{
-	S3Desc,
+	// TODO: disabled for now
+	//S3Desc,
 }


### PR DESCRIPTION
disable uploader for the moment, until a solution is found so that library users can override the configuration