### PR TITLE
Outputs return an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not force GOGC=800, let inputs decide and user have final word [#13](https://github.com/AdRoll/baker/pull/13)
 - Move aws-specific utilities into a new `awsutils` package [#14](https://github.com/AdRoll/baker/pull/14)
+- Outputs' `Run()` returns an error [#21](https://github.com/AdRoll/baker/pull/21)
 
 ### Removed
 

--- a/api.go
+++ b/api.go
@@ -102,7 +102,7 @@ type Output interface {
 	// TODO: since Run must be blocking, it could return an error, useful
 	// for the topology to acknowledge the correct processing if nil, or
 	// end the whole topology in case non-nil.
-	Run(in <-chan OutputRecord, upch chan<- string)
+	Run(in <-chan OutputRecord, upch chan<- string) error
 
 	// Stats returns stats about the output.
 	Stats() OutputStats

--- a/examples/sharding/output.go
+++ b/examples/sharding/output.go
@@ -32,13 +32,15 @@ func (s *Shardable) CanShard() bool {
 	return true
 }
 
-func (s *Shardable) Run(input <-chan baker.OutputRecord, _ chan<- string) {
+func (s *Shardable) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	// Do something with `input` record.
 	// s.idx identifies the output process index and should
 	// be used to manage the sharding
 	for data := range input {
 		log.Printf(`Shard #%d: Getting "%s"`, s.idx, data.Record)
 	}
+
+	return nil
 }
 
 func (s *Shardable) Stats() baker.OutputStats { return baker.OutputStats{} }

--- a/output/dyndb.go
+++ b/output/dyndb.go
@@ -384,11 +384,13 @@ func (b *DynamoWriter) flush() {
 	b.reqn = 0
 }
 
-func (b *DynamoWriter) Run(input <-chan baker.OutputRecord, _ chan<- string) {
+func (b *DynamoWriter) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	for lldata := range input {
 		b.push(lldata.Fields)
 	}
 	b.Flush()
+
+	return nil
 }
 
 func (b *DynamoWriter) Stats() baker.OutputStats {

--- a/output/filewriter.go
+++ b/output/filewriter.go
@@ -135,7 +135,7 @@ func NewFileWriter(cfg baker.OutputParams) (baker.Output, error) {
 	}, nil
 }
 
-func (w *FileWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) {
+func (w *FileWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) error {
 	log.WithFields(log.Fields{"idx": w.index}).Info("FileWriter ready to log")
 
 	for lldata := range input {
@@ -164,6 +164,8 @@ func (w *FileWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) {
 	for _, worker := range w.workers {
 		worker.Wait()
 	}
+
+	return nil
 }
 
 func (w *FileWriter) Stats() baker.OutputStats {

--- a/output/nop.go
+++ b/output/nop.go
@@ -23,10 +23,12 @@ func NewNopWriter(cfg baker.OutputParams) (baker.Output, error) {
 
 func (b *NopWriter) CanShard() bool { return true }
 
-func (nop *NopWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) {
+func (nop *NopWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) error {
 	for range input {
 		atomic.AddInt64(&nop.totaln, 1)
 	}
+
+	return nil
 }
 
 func (nop *NopWriter) Stats() baker.OutputStats {

--- a/output/oplog.go
+++ b/output/oplog.go
@@ -41,12 +41,14 @@ func NewOpLog(cfg baker.OutputParams) (baker.Output, error) {
 	}, nil
 }
 
-func (w *OpLog) Run(input <-chan baker.OutputRecord, _ chan<- string) {
+func (w *OpLog) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	log.Info("OpLog ready to log")
 	for lldata := range input {
 		log.WithFields(log.Fields{"line": lldata.Fields}).Info(".")
 		atomic.AddInt64(&w.totaln, int64(1))
 	}
+
+	return nil
 }
 
 func (w *OpLog) Stats() baker.OutputStats {

--- a/output/outputtest/recorder.go
+++ b/output/outputtest/recorder.go
@@ -32,10 +32,12 @@ func NewRecorder(cfg baker.OutputParams) (baker.Output, error) {
 }
 
 // Run implements baker.Output interface.
-func (r *Recorder) Run(input <-chan baker.OutputRecord, _ chan<- string) {
+func (r *Recorder) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	for lldata := range input {
 		r.Records = append(r.Records, lldata)
 	}
+
+	return nil
 }
 
 // Stats implements baker.Output interface.

--- a/output/websocket.go
+++ b/output/websocket.go
@@ -48,7 +48,7 @@ func NewWebSocketWriter(cfg baker.OutputParams) (baker.Output, error) {
 
 // websocket server
 
-func (w *WebSocketWriter) Run(input <-chan baker.OutputRecord, _ chan<- string) {
+func (w *WebSocketWriter) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	cfg := websocket.Conf{
 		Fields:      w.Fields,
 		FieldByName: w.fieldByName,
@@ -65,6 +65,8 @@ func (w *WebSocketWriter) Run(input <-chan baker.OutputRecord, _ chan<- string) 
 		server.SendAll(lldata.Fields)
 		atomic.AddInt64(&w.totaln, int64(1))
 	}
+
+	return nil
 }
 
 func (w *WebSocketWriter) Stats() baker.OutputStats {

--- a/topology.go
+++ b/topology.go
@@ -214,7 +214,9 @@ func (t *Topology) Start() {
 			ch = t.outch[0]
 		}
 		go func(out Output) {
-			out.Run(ch, t.upch)
+			if err := out.Run(ch, t.upch); err != nil {
+				log.WithError(err).Fatal("Output returned an error")
+			}
 			t.wgout.Done()
 		}(out)
 	}


### PR DESCRIPTION
#### :question: What

The outputs now return an error.
This is handy so that each output isn't responsible to terminate baker with `panic` or `os.Exit`, but is the topology to handle it. And in case we want to change the behaviour in the future, there's no need to change the API

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
