### PR TITLE
Fix upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Maintenance
 
 - input: Fixes `List` input not managing S3 "folders" [#35](https://github.com/AdRoll/baker/pull/35)
+- upload: fixes a severe concurrency issue in the uploader [#38](https://github.com/AdRoll/baker/pull/38)

--- a/upload/s3.go
+++ b/upload/s3.go
@@ -116,6 +116,10 @@ func newS3(cfg baker.UploadParams) (baker.Upload, error) {
 		return nil, fmt.Errorf("upload.s3: %v", err)
 	}
 
+	if err := os.MkdirAll(dcfg.StagingPath, 0777); err != nil {
+		return nil, fmt.Errorf("staging path creation error: %v", err)
+	}
+
 	s3svc := s3.New(session.New(&aws.Config{Region: aws.String(dcfg.Region)}))
 	return &S3{
 		Cfg:      dcfg,


### PR DESCRIPTION
#### :question: What

1. fixes a concurrency error when `uploadDirectory` returns an error and `ExitOnError = true`
1. fixes the error that made us discover the above bug: the staging path is created by the `move` function, but it's not created when the output doesn't produce any file. This caused an error in the uploader because of the missing staging path. Now the staging folder is created in the constructor