### PR TITLE
input.list: restore s3 manifest feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Maintenance
 
 - input: Fixes `List` input not managing S3 "folders" [#35](https://github.com/AdRoll/baker/pull/35)
+- input: with [#35](https://github.com/AdRoll/baker/pull/35) we introduced a regression that has been fixed with [#39](https://github.com/AdRoll/baker/pull/39)
 - upload: fixes a severe concurrency issue in the uploader [#38](https://github.com/AdRoll/baker/pull/38)


### PR DESCRIPTION
#### :question: What

https://github.com/AdRoll/baker/pull/35 removed an expected functionality of the List input: consuming a S3 manifest file containing a list of files to download and ingest.
This PR restores it back

#### :white_check_mark: Checklists

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
