### PR TITLE
Add s3 upload integration tests

### DIFF
--- a/upload/s3_integration_test.go
+++ b/upload/s3_integration_test.go
@@ -28,6 +28,8 @@ type customOutput struct {
 	sleep time.Duration // sleep duration after each file written
 }
 
+func nthFile(n int) string { return fmt.Sprintf("file.%02d", n) }
+
 func (o *customOutput) Stats() baker.OutputStats { return baker.OutputStats{} }
 func (o *customOutput) CanShard() bool           { return false }
 
@@ -35,7 +37,7 @@ func (o *customOutput) Run(in <-chan baker.OutputRecord, upch chan<- string) err
 	// Simulate a new file for each received record
 	nfiles := 0
 	for range in {
-		fpath := path.Join(o.path, fmt.Sprintf("file.%d", nfiles))
+		fpath := path.Join(o.path, nthFile(nfiles))
 		if err := ioutil.WriteFile(fpath, nil, 0664); err != nil {
 			return err
 		}
@@ -47,6 +49,106 @@ func (o *customOutput) Run(in <-chan baker.OutputRecord, upch chan<- string) err
 	return nil
 }
 
+func testIntegrationS3(callStop bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		defer testutil.DisableLogging()()
+
+		toml := `
+		[input]
+		name="records"
+	
+		[output]
+		name="custom"
+		procs=1
+	
+		[upload]
+		name="s3"
+	
+			[upload.config]
+			sourcebasepath=%q
+			stagingpath=%q
+			bucket="my-bucket"
+			interval="10ms"
+			retries=1
+			concurrency=1`
+
+		/* Configure the pipeline */
+
+		comp := baker.Components{
+			Inputs:  []baker.InputDesc{inputtest.RecordsDesc},
+			Outputs: []baker.OutputDesc{customOutputDesc},
+			Uploads: []baker.UploadDesc{S3Desc},
+		}
+
+		basePath, stagingPath := t.TempDir(), t.TempDir()
+		r := strings.NewReader(fmt.Sprintf(toml, basePath, stagingPath))
+		cfg, err := baker.NewConfigFromToml(r, comp)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		topo, err := baker.NewTopologyFromConfig(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Upload: mock AWS S3
+		u := topo.Upload.(*S3)
+		s, ops, params := mockS3Service(false)
+		u.uploader = s3manager.NewUploaderWithClient(s)
+
+		// Output: provide the path in which files should be written
+		o := topo.Output[0].(*customOutput)
+		o.path = basePath
+
+		const nfiles = 100
+
+		// Input: create some dummy records
+		// since the custom output is creating one file per received record,
+		// we create 'nfiles' records.
+		var records []baker.Record
+		for i := 0; i < nfiles; i++ {
+			l := baker.LogLine{}
+			l.Parse([]byte("dummyrecord"), nil)
+			records = append(records, &l)
+		}
+		topo.Input.(*inputtest.Records).Records = records
+
+		/* Run the pipeline */
+
+		topo.Start()
+		if callStop {
+			time.Sleep(100 * time.Millisecond)
+			topo.Stop()
+		}
+		topo.Wait()
+		if err := topo.Error(); err != nil {
+			t.Fatalf("topology error: %v", err)
+		}
+
+		/* Checks */
+
+		// Check files have been all uploaded
+		for i := range *ops {
+			if (*ops)[i] != "PutObject" {
+				t.Errorf("got operation %d/%d = %q, want %q", i, nfiles, (*ops)[i], "PutObject")
+			}
+		}
+		// *s3.PutObjectInput
+		for i := range *params {
+			put := (*params)[i].(*s3.PutObjectInput)
+			if *put.Bucket != "my-bucket" {
+				t.Errorf("got operation %d/%d bucket = %q, want %q", i, nfiles, *put.Bucket, "my-bucket")
+			}
+
+			wantKey := "/" + nthFile(i)
+			if *put.Key != wantKey {
+				t.Errorf("got operation %d/%d key = %q, want %q", i, nfiles, *put.Key, wantKey)
+			}
+		}
+	}
+}
+
 func TestIntegrationS3(t *testing.T) {
 	// This test configures a pipelines from the ground up by passing it a TOML,
 	// mocks S3 to not rely on an external service. The created topology is then
@@ -55,97 +157,14 @@ func TestIntegrationS3(t *testing.T) {
 	// exits).
 	//
 	// The topology should end by itself without any error, we also checks that
+	t.Run("topololy.wait", testIntegrationS3(false))
+
 	// the expected number of files have been uploaded and their expected bucket/key.
-
-	defer testutil.DisableLogging()()
-
-	toml := `
-	[input]
-	name="records"
-
-	[output]
-	name="custom"
-	procs=1
-
-	[upload]
-	name="s3"
-
-		[upload.config]
-		sourcebasepath=%q
-		stagingpath=%q
-		bucket="my-bucket"
-		interval="10ms"
-		retries=1
-		concurrency=1`
-
-	/* Configure the pipeline */
-
-	comp := baker.Components{
-		Inputs:  []baker.InputDesc{inputtest.RecordsDesc},
-		Outputs: []baker.OutputDesc{customOutputDesc},
-		Uploads: []baker.UploadDesc{S3Desc},
-	}
-
-	basePath, stagingPath := t.TempDir(), t.TempDir()
-	r := strings.NewReader(fmt.Sprintf(toml, basePath, stagingPath))
-	cfg, err := baker.NewConfigFromToml(r, comp)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	topo, err := baker.NewTopologyFromConfig(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Upload: mock AWS S3
-	u := topo.Upload.(*S3)
-	s, ops, params := mockS3Service(false)
-	u.uploader = s3manager.NewUploaderWithClient(s)
-
-	// Output: provide the path in which files should be written
-	o := topo.Output[0].(*customOutput)
-	o.path = basePath
-
-	const nfiles = 10
-
-	// Input: create some dummy records
-	// since the custom output is creating one file per received record,
-	// we create 'nfiles' records.
-	var records []baker.Record
-	for i := 0; i < nfiles; i++ {
-		l := baker.LogLine{}
-		l.Parse([]byte("dummyrecord"), nil)
-		records = append(records, &l)
-	}
-	topo.Input.(*inputtest.Records).Records = records
-
-	/* Run the pipeline */
-
-	topo.Start()
-	topo.Wait()
-	if err := topo.Error(); err != nil {
-		t.Fatalf("topology error: %v", err)
-	}
-
-	/* Checks */
-
-	// Check files have been all uploaded
-	for i := range *ops {
-		if (*ops)[i] != "PutObject" {
-			t.Errorf("got operation %d/%d = %q, want %q", i, nfiles, (*ops)[i], "PutObject")
-		}
-	}
-	// *s3.PutObjectInput
-	for i := range *params {
-		put := (*params)[i].(*s3.PutObjectInput)
-		if *put.Bucket != "my-bucket" {
-			t.Errorf("got operation %d/%d bucket = %q, want %q", i, nfiles, *put.Bucket, "my-bucket")
-		}
-
-		wantKey := fmt.Sprintf("/file.%d", i)
-		if *put.Key != wantKey {
-			t.Errorf("got operation %d/%d key = %q, want %q", i, nfiles, *put.Key, wantKey)
-		}
-	}
+	// On the second subtest we immeditately stop the topology after starting it,
+	// but the outcome should be the same since we wait enough time for the input
+	// to produce the records, which means topology.Stop() should block until:
+	//  - all records have been processed,
+	//  - all files have been written by the output
+	//  - all files have been uplodaed by the S3 upload
+	t.Run("topololy.stop", testIntegrationS3(true))
 }

--- a/upload/s3_integration_test.go
+++ b/upload/s3_integration_test.go
@@ -1,0 +1,151 @@
+package upload
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
+	"github.com/AdRoll/baker"
+	"github.com/AdRoll/baker/input/inputtest"
+	"github.com/AdRoll/baker/testutil"
+)
+
+var customOutputDesc = baker.OutputDesc{
+	Name:   "custom",
+	New:    func(baker.OutputParams) (baker.Output, error) { return &customOutput{}, nil },
+	Config: &struct{}{},
+	Raw:    true,
+}
+
+type customOutput struct {
+	path  string
+	sleep time.Duration // sleep duration after each file written
+}
+
+func (o *customOutput) Stats() baker.OutputStats { return baker.OutputStats{} }
+func (o *customOutput) CanShard() bool           { return false }
+
+func (o *customOutput) Run(in <-chan baker.OutputRecord, upch chan<- string) error {
+	// Simulate a new file for each received record
+	nfiles := 0
+	for range in {
+		fpath := path.Join(o.path, fmt.Sprintf("file.%d", nfiles))
+		if err := ioutil.WriteFile(fpath, nil, 0664); err != nil {
+			return err
+		}
+		nfiles++
+		upch <- fpath
+		time.Sleep(o.sleep)
+	}
+
+	return nil
+}
+
+func TestIntegrationS3(t *testing.T) {
+	// This test configures a pipelines from the ground up by passing it a TOML,
+	// mocks S3 to not rely on an external service. The created topology is then
+	// ran in conditions that are very similar to what would happen in production
+	// with a batch workload (i.e process an pre-specified amount of record and
+	// exits).
+	//
+	// The topology should end by itself without any error, we also checks that
+	// the expected number of files have been uploaded and their expected bucket/key.
+
+	defer testutil.DisableLogging()()
+
+	toml := `
+	[input]
+	name="records"
+
+	[output]
+	name="custom"
+	procs=1
+
+	[upload]
+	name="s3"
+
+		[upload.config]
+		sourcebasepath=%q
+		stagingpath=%q
+		bucket="my-bucket"
+		interval="10ms"
+		retries=1
+		concurrency=1`
+
+	/* Configure the pipeline */
+
+	comp := baker.Components{
+		Inputs:  []baker.InputDesc{inputtest.RecordsDesc},
+		Outputs: []baker.OutputDesc{customOutputDesc},
+		Uploads: []baker.UploadDesc{S3Desc},
+	}
+
+	basePath, stagingPath := t.TempDir(), t.TempDir()
+	r := strings.NewReader(fmt.Sprintf(toml, basePath, stagingPath))
+	cfg, err := baker.NewConfigFromToml(r, comp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topo, err := baker.NewTopologyFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload: mock AWS S3
+	u := topo.Upload.(*S3)
+	s, ops, params := mockS3Service(false)
+	u.uploader = s3manager.NewUploaderWithClient(s)
+
+	// Output: provide the path in which files should be written
+	o := topo.Output[0].(*customOutput)
+	o.path = basePath
+
+	const nfiles = 10
+
+	// Input: create some dummy records
+	// since the custom output is creating one file per received record,
+	// we create 'nfiles' records.
+	var records []baker.Record
+	for i := 0; i < nfiles; i++ {
+		l := baker.LogLine{}
+		l.Parse([]byte("dummyrecord"), nil)
+		records = append(records, &l)
+	}
+	topo.Input.(*inputtest.Records).Records = records
+
+	/* Run the pipeline */
+
+	topo.Start()
+	topo.Wait()
+	if err := topo.Error(); err != nil {
+		t.Fatalf("topology error: %v", err)
+	}
+
+	/* Checks */
+
+	// Check files have been all uploaded
+	for i := range *ops {
+		if (*ops)[i] != "PutObject" {
+			t.Errorf("got operation %d/%d = %q, want %q", i, nfiles, (*ops)[i], "PutObject")
+		}
+	}
+	// *s3.PutObjectInput
+	for i := range *params {
+		put := (*params)[i].(*s3.PutObjectInput)
+		if *put.Bucket != "my-bucket" {
+			t.Errorf("got operation %d/%d bucket = %q, want %q", i, nfiles, *put.Bucket, "my-bucket")
+		}
+
+		wantKey := fmt.Sprintf("/file.%d", i)
+		if *put.Key != wantKey {
+			t.Errorf("got operation %d/%d key = %q, want %q", i, nfiles, *put.Key, wantKey)
+		}
+	}
+}

--- a/upload/s3_integration_test.go
+++ b/upload/s3_integration_test.go
@@ -159,7 +159,7 @@ func TestIntegrationS3(t *testing.T) {
 	// The topology should end by itself without any error, we also checks that
 	t.Run("topololy.wait", testIntegrationS3(false))
 
-	// the expected number of files have been uploaded and their expected bucket/key.
+	// the expected number of files have been uploaded to their expected bucket/key.
 	// On the second subtest we immeditately stop the topology after starting it,
 	// but the outcome should be the same since we wait enough time for the input
 	// to produce the records, which means topology.Stop() should block until:

--- a/upload/s3_test.go
+++ b/upload/s3_test.go
@@ -333,19 +333,16 @@ func TestRun(t *testing.T) {
 	u := iu.(*S3)
 	u.uploader = s3manager.NewUploaderWithClient(s)
 
-	upCh := make(chan string)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	ch := make(chan string)
 	go func() {
-		defer wg.Done()
-		if err := u.Run(upCh); err != nil {
-			t.Fatal(err)
-		}
+		ch <- fname
+		close(ch)
 	}()
 
-	upCh <- fname
-	close(upCh)
-	wg.Wait()
+	err = u.Run(ch)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if int(u.totalerr) != 0 {
 		t.Fatalf("totalerr: want: %d, got: %d", 0, int(u.totalerr))
@@ -382,19 +379,16 @@ func TestRunExitOnError(t *testing.T) {
 	u := iu.(*S3)
 	u.uploader = s3manager.NewUploaderWithClient(s)
 
-	upCh := make(chan string)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	ch := make(chan string)
 	go func() {
-		defer wg.Done()
-		if err := u.Run(upCh); err != nil {
-			t.Fatal(err)
-		}
+		ch <- fname
+		close(ch)
 	}()
 
-	upCh <- fname
-	close(upCh)
-	wg.Wait()
+	err = u.Run(ch)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if int(u.totalerr) != 1 {
 		t.Fatalf("totalerr: want: %d, got: %d", 1, int(u.totalerr))
@@ -434,19 +428,16 @@ func TestRunNotExitOnError(t *testing.T) {
 	u := iu.(*S3)
 	u.uploader = s3manager.NewUploaderWithClient(s)
 
-	upCh := make(chan string)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	ch := make(chan string)
 	go func() {
-		defer wg.Done()
-		if err := u.Run(upCh); err != nil {
-			t.Fatal(err)
-		}
+		ch <- fname
+		close(ch)
 	}()
 
-	upCh <- fname
-	close(upCh)
-	wg.Wait()
+	err = u.Run(ch)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if int(u.totalerr) > 1*u.Cfg.Retries {
 		t.Fatalf("totalerr: want: <=%d, got: %d", 1*u.Cfg.Retries, int(u.totalerr))

--- a/upload/s3_test.go
+++ b/upload/s3_test.go
@@ -194,7 +194,7 @@ func TestS3Upload(t *testing.T) {
 	}
 }
 
-func Test_uploadDirectory(t *testing.T) {
+func TestS3_uploadDirectory(t *testing.T) {
 	defer testutil.DisableLogging()()
 	// Create a folder to store files to be uploaded
 	numFiles := 10
@@ -234,7 +234,7 @@ func Test_uploadDirectory(t *testing.T) {
 	}
 }
 
-func Test_uploadDirectoryError(t *testing.T) {
+func TestS3_uploadDirectoryError(t *testing.T) {
 	defer testutil.DisableLogging()()
 
 	numFiles := 10
@@ -306,54 +306,7 @@ func Test_uploadDirectoryError(t *testing.T) {
 	})
 }
 
-func TestRun(t *testing.T) {
-	defer testutil.DisableLogging()()
-
-	tmpDir, fnames := prepareUploadS3TestFolder(t, 1)
-	fname := fnames[0]
-
-	stagingDir := t.TempDir()
-
-	cfg := baker.UploadParams{
-		ComponentParams: baker.ComponentParams{
-			DecodedConfig: &S3Config{
-				SourceBasePath: stagingDir,
-				StagingPath:    tmpDir,
-				Bucket:         "my-bucket",
-				Concurrency:    5,
-				Retries:        3,
-			},
-		},
-	}
-	iu, err := newS3(cfg)
-	if err != nil {
-		t.Fatalf("NewS3Upload(%+v) = %q", cfg, err)
-	}
-	s, _, _ := mockS3Service(false)
-	u := iu.(*S3)
-	u.uploader = s3manager.NewUploaderWithClient(s)
-
-	ch := make(chan string)
-	go func() {
-		ch <- fname
-		close(ch)
-	}()
-
-	err = u.Run(ch)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if int(u.totalerr) != 0 {
-		t.Fatalf("totalerr: want: %d, got: %d", 0, int(u.totalerr))
-	}
-
-	if int(u.totaln) != 1 {
-		t.Fatalf("totaln: want: %d, got: %d", 1, int(u.totaln))
-	}
-}
-
-func TestRunExitOnError(t *testing.T) {
+func TestS3RunExitOnError(t *testing.T) {
 	defer testutil.DisableLogging()()
 
 	tmpDir, fnames := prepareUploadS3TestFolder(t, 1)
@@ -399,7 +352,7 @@ func TestRunExitOnError(t *testing.T) {
 	}
 }
 
-func TestRunNotExitOnError(t *testing.T) {
+func TestS3RunNotExitOnError(t *testing.T) {
 	defer testutil.DisableLogging()()
 
 	tmpDir, fnames := prepareUploadS3TestFolder(t, 1)
@@ -448,7 +401,7 @@ func TestRunNotExitOnError(t *testing.T) {
 	}
 }
 
-func Test_move(t *testing.T) {
+func TestS3_move(t *testing.T) {
 	srcDir := t.TempDir()
 	trgtDir := t.TempDir()
 


### PR DESCRIPTION
#### :question: What

Add some integration tests of the s3 upload in order to fix the upload-topology interaction in stone.
A first test verifies the uploader uploads all produced files if we block on `topology.Wait`
A second test stops the topology (as a CTRL-C would do) and ensure all produced files are also uploaded

#### :hammer: How to test

Just call `go test -race -run TestIntegrationS3 ./upload`

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
