### PR TITLE
Add Record.Copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - filter: add TimestampRange filter [#46](https://github.com/AdRoll/baker/pull/46)
 - filter: add ReplaceFields filter [#49](https://github.com/AdRoll/baker/pull/49)
 - filter: add Timestamp filter [#54](https://github.com/AdRoll/baker/pull/54)
+- Add Record.Copy method [#53](https://github.com/AdRoll/baker/pull/53)
 
 ### Changed
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -133,7 +133,7 @@ func BenchmarkLogLineParse(b *testing.B) {
 
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		ll.Parse(buf, &md)
+		ll.Parse(buf, md)
 	}
 	sink = ll
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -138,41 +138,108 @@ func BenchmarkLogLineParse(b *testing.B) {
 	sink = ll
 }
 
-func BenchmarkLogLineCopyParsed(b *testing.B) {
-	var ll baker.Record
-	ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
-	buf := bytes.Repeat([]byte(`hello,world,,`), 200)
-	ll.Parse(buf, nil)
+func BenchmarkLogLineCopy(b *testing.B) {
+	b.Run("set=0", func(b *testing.B) {
+		var ll baker.Record
+		ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+		buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+		ll.Parse(buf, nil)
 
-	b.ReportAllocs()
+		b.ReportAllocs()
 
-	var cpy baker.Record
-	for n := 0; n < b.N; n++ {
-		cpy = ll.Copy()
-	}
-	sink = cpy
+		var cpy baker.Record
+		for n := 0; n < b.N; n++ {
+			cpy = ll.Copy()
+		}
 
-	if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
-		b.Error("copy != original")
-	}
-}
+		if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+			b.Error("copy != original")
+		}
+	})
 
-func BenchmarkLogLineCopyModified(b *testing.B) {
-	var ll baker.Record
-	ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
-	buf := bytes.Repeat([]byte(`hello,world,,`), 200)
-	ll.Parse(buf, nil)
-	ll.Set(0, []byte("foobar"))
+	b.Run("set=1", func(b *testing.B) {
+		var ll baker.Record
+		ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+		buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+		ll.Parse(buf, nil)
+		ll.Set(0, []byte("foobar"))
 
-	b.ReportAllocs()
+		b.ReportAllocs()
 
-	var cpy baker.Record
-	for n := 0; n < b.N; n++ {
-		cpy = ll.Copy()
-	}
-	sink = cpy
+		var cpy baker.Record
+		for n := 0; n < b.N; n++ {
+			cpy = ll.Copy()
+		}
 
-	if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
-		b.Error("copy != original")
-	}
+		if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+			b.Error("copy != original")
+		}
+	})
+
+	b.Run("set=10", func(b *testing.B) {
+		var ll baker.Record
+		ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+		buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+		ll.Parse(buf, nil)
+		ll.Set(0, []byte("foobar"))
+		ll.Set(2, []byte("foobar"))
+		ll.Set(3, []byte("foobar"))
+		ll.Set(6, []byte("foobar"))
+		ll.Set(30, []byte("foobar"))
+		ll.Set(79, []byte("foobar"))
+		ll.Set(124, []byte("foobar"))
+		ll.Set(189, []byte("foobar"))
+		ll.Set(234, []byte("foobar"))
+		ll.Set(798, []byte("foobar"))
+
+		b.ReportAllocs()
+
+		var cpy baker.Record
+		for n := 0; n < b.N; n++ {
+			cpy = ll.Copy()
+		}
+
+		if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+			b.Error("copy != original")
+		}
+	})
+
+	b.Run("set=20", func(b *testing.B) {
+		var ll baker.Record
+		ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+		buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+		ll.Parse(buf, nil)
+		ll.Set(0, []byte("foobar"))
+		ll.Set(2, []byte("foobar"))
+		ll.Set(3, []byte("foobar"))
+		ll.Set(6, []byte("foobar"))
+		ll.Set(30, []byte("foobar"))
+		ll.Set(79, []byte("foobar"))
+		ll.Set(124, []byte("foobar"))
+		ll.Set(189, []byte("foobar"))
+		ll.Set(234, []byte("foobar"))
+		ll.Set(798, []byte("foobar"))
+
+		ll.Set(801, []byte("foobar"))
+		ll.Set(810, []byte("foobar"))
+		ll.Set(888, []byte("foobar"))
+		ll.Set(902, []byte("foobar"))
+		ll.Set(1000, []byte("foobar"))
+		ll.Set(1001, []byte("foobar"))
+		ll.Set(1002, []byte("foobar"))
+		ll.Set(1200, []byte("foobar"))
+		ll.Set(1356, []byte("foobar"))
+		ll.Set(1789, []byte("foobar"))
+
+		b.ReportAllocs()
+
+		var cpy baker.Record
+		for n := 0; n < b.N; n++ {
+			cpy = ll.Copy()
+		}
+
+		if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+			b.Error("copy != original")
+		}
+	})
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -137,3 +137,42 @@ func BenchmarkLogLineParse(b *testing.B) {
 	}
 	sink = ll
 }
+
+func BenchmarkLogLineCopyParsed(b *testing.B) {
+	var ll baker.Record
+	ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+	buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+	ll.Parse(buf, nil)
+
+	b.ReportAllocs()
+
+	var cpy baker.Record
+	for n := 0; n < b.N; n++ {
+		cpy = ll.Copy()
+	}
+	sink = cpy
+
+	if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+		b.Error("copy != original")
+	}
+}
+
+func BenchmarkLogLineCopyModified(b *testing.B) {
+	var ll baker.Record
+	ll = &baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
+	buf := bytes.Repeat([]byte(`hello,world,,`), 200)
+	ll.Parse(buf, nil)
+	ll.Set(0, []byte("foobar"))
+
+	b.ReportAllocs()
+
+	var cpy baker.Record
+	for n := 0; n < b.N; n++ {
+		cpy = ll.Copy()
+	}
+	sink = cpy
+
+	if !bytes.Equal(ll.ToText(nil), cpy.ToText(nil)) {
+		b.Error("copy != original")
+	}
+}

--- a/filter/set_string_from_url_test.go
+++ b/filter/set_string_from_url_test.go
@@ -47,7 +47,7 @@ func TestSetStringFromURL(t *testing.T) {
 			}
 
 			ll := &baker.LogLine{}
-			ll.Parse(nil, &baker.Metadata{inpututils.MetadataURL: u})
+			ll.Parse(nil, baker.Metadata{inpututils.MetadataURL: u})
 
 			// Create and setup a filter with tt.strings
 			strings := make([][]byte, 0, len(tt.strings))

--- a/logline.go
+++ b/logline.go
@@ -113,7 +113,7 @@ var errLogLineTooManyFields = errors.New("LogLine has too many fields")
 // instance. For performance reasons, it doesn't reset all the writable fields
 // of the line. If you want to use Parse over an already parsed LogLine, use
 // Clear before.
-func (l *LogLine) Parse(text []byte, meta *Metadata) error {
+func (l *LogLine) Parse(text []byte, meta Metadata) error {
 	l.idx[0] = -1
 	fc := FieldIndex(1)
 	for i, ch := range text {
@@ -130,7 +130,7 @@ func (l *LogLine) Parse(text []byte, meta *Metadata) error {
 	}
 	l.data = text
 	if meta != nil {
-		l.meta = *meta
+		l.meta = meta
 	}
 
 	return nil

--- a/logline.go
+++ b/logline.go
@@ -208,13 +208,39 @@ func (l *LogLine) Cache() *Cache {
 
 // Copy creates and returns a copy of the current log line.
 func (l *LogLine) Copy() Record {
+	// Copy metadata
 	md := make(Metadata)
-
 	for k, v := range l.meta {
 		md[k] = v
 	}
 
-	cpy := LogLine{}
-	cpy.Parse(l.ToText(nil), md)
-	return &cpy
+	cpy := &LogLine{
+		cache:          l.cache,
+		wcnt:           l.wcnt,
+		meta:           md,
+		FieldSeparator: l.FieldSeparator,
+	}
+
+	if l.data != nil {
+		cpy.data = make([]byte, len(l.data))
+		copy(cpy.data, l.data)
+	}
+
+	if cpy.wcnt == 0 {
+		// Log line hasn't been modified so we can early exit and
+		// let idx, wmask and wdata to their zero-values.
+		return cpy
+	}
+
+	copy(cpy.idx[:], l.idx[:])
+	copy(cpy.wmask[:], l.wmask[:])
+
+	for i := 0; i < len(l.wdata); i++ {
+		if l.wdata[i] != nil {
+			cpy.wdata[i] = make([]byte, len(l.wdata[i]))
+			copy(cpy.wdata[i], l.wdata[i])
+		}
+	}
+
+	return cpy
 }

--- a/logline.go
+++ b/logline.go
@@ -205,3 +205,16 @@ func (l *LogLine) Meta(key string) (interface{}, bool) {
 func (l *LogLine) Cache() *Cache {
 	return &l.cache
 }
+
+// Copy creates and returns a copy of the current log line.
+func (l *LogLine) Copy() Record {
+	md := make(Metadata)
+
+	for k, v := range l.meta {
+		md[k] = v
+	}
+
+	cpy := LogLine{}
+	cpy.Parse(l.ToText(nil), md)
+	return &cpy
+}

--- a/logline.go
+++ b/logline.go
@@ -232,14 +232,14 @@ func (l *LogLine) Copy() Record {
 		return cpy
 	}
 
-	copy(cpy.idx[:], l.idx[:])
-	copy(cpy.wmask[:], l.wmask[:])
+	// Copy read-only fields
+	cpy.idx = l.idx
 
-	for i := 0; i < len(l.wdata); i++ {
-		if l.wdata[i] != nil {
-			cpy.wdata[i] = make([]byte, len(l.wdata[i]))
-			copy(cpy.wdata[i], l.wdata[i])
-		}
+	// Copy modified fields
+	cpy.wmask = l.wmask
+	for i := uint8(0); i <= cpy.wcnt; i++ {
+		cpy.wdata[i] = make([]byte, len(l.wdata[i]))
+		copy(cpy.wdata[i], l.wdata[i])
 	}
 
 	return cpy

--- a/logline.go
+++ b/logline.go
@@ -221,13 +221,14 @@ func (l *LogLine) Copy() Record {
 	}
 
 	if l.wcnt != 0 {
-		// If the log line has been modified, benchmarks have proven
-		// that it's more efficient to serialize and reparse to perform
-		// a copy (both in terms of time and allocation.
-		cpylen := len(l.data) + len(l.data)/2
+		// If the log line has been modified, benchmarks have proven that it's
+		// more efficient to serialize and reparse to perform a copy (both in
+		// terms of time and allocation). Also, different benchmarks have shown
+		// that pre-allocating 120% of the original log line length in order to
+		// account for the potentially added fields is reasonable.
+		cpylen := len(l.data) + len(l.data)/5
 		text := l.ToText(make([]byte, 0, cpylen))
 		cpy.Parse(text, md)
-
 		return cpy
 	}
 

--- a/logline.go
+++ b/logline.go
@@ -216,12 +216,11 @@ func (l *LogLine) Copy() Record {
 
 	cpy := &LogLine{
 		cache:          l.cache,
-		wcnt:           l.wcnt,
 		meta:           md,
 		FieldSeparator: l.FieldSeparator,
 	}
 
-	if cpy.wcnt != 0 {
+	if l.wcnt != 0 {
 		// If the log line has been modified, benchmarks have proven
 		// that it's more efficient to serialize and reparse to perform
 		// a copy (both in terms of time and allocation.

--- a/logline_test.go
+++ b/logline_test.go
@@ -82,7 +82,7 @@ func TestLogLineMeta(t *testing.T) {
 		t.Errorf("ll.Meta(%q) = _, %v;  want _, false", "foo", ok)
 	}
 
-	ll.Parse(nil, &Metadata{"foo": 23})
+	ll.Parse(nil, Metadata{"foo": 23})
 	val, ok := ll.Meta("foo")
 	if !ok || val != 23 {
 		t.Errorf("ll.Meta(%q) = %v, %v;  want 23, true", "foo", val, ok)

--- a/logline_test.go
+++ b/logline_test.go
@@ -124,7 +124,11 @@ func TestLogLineCache(t *testing.T) {
 }
 
 func TestLogLineRecordConformance(t *testing.T) {
-	RecordConformanceTest(t, &LogLine{FieldSeparator: DefaultLogLineFieldSeparator})
+	createLogLine := func() Record {
+		return &LogLine{FieldSeparator: DefaultLogLineFieldSeparator}
+	}
+
+	RecordConformanceTest(t, createLogLine)
 }
 
 func TestLogLineParseCustomSeparator(t *testing.T) {

--- a/record.go
+++ b/record.go
@@ -20,6 +20,15 @@ type Record interface {
 	// record.
 	ToText(buf []byte) []byte
 
+	// Copy creates and returns a copy of the current record.
+	//
+	// The copied record could have been obtained by:
+	//  var dst Record
+	//  src.Parse(dst.ToText(), nil)
+	//
+	// but Record implementations should provide a more efficient way.
+	Copy() Record
+
 	// Clear clears the record internal state, making it empty.
 	Clear()
 

--- a/record.go
+++ b/record.go
@@ -12,7 +12,7 @@ type Record interface {
 	// The given Metadata will be attached to that record. Record
 	// implementations should also accept a nil in case the record has no
 	// Metadata attached.
-	Parse([]byte, *Metadata) error
+	Parse([]byte, Metadata) error
 
 	// ToText returns the reconstructed data format of a record.
 	//

--- a/test_helper.go
+++ b/test_helper.go
@@ -2,15 +2,17 @@ package baker
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
 // RecordConformanceTest is a test helper that verifies the conformance of
 // Record implementation with a set of requirements.
-func RecordConformanceTest(t *testing.T, r Record) {
+func RecordConformanceTest(t *testing.T, create func() Record) {
 	t.Helper()
 
 	t.Run("valid-zero-value", func(t *testing.T) {
+		r := create()
 		r.Set(0, []byte("stuff"))
 		r.Set(1, []byte("other stuff"))
 		got := r.Get(0)
@@ -25,6 +27,7 @@ func RecordConformanceTest(t *testing.T, r Record) {
 	})
 
 	t.Run("valid-after-clear", func(t *testing.T) {
+		r := create()
 		r.Set(0, []byte("stuff"))
 		r.Clear()
 		got := r.Get(0)
@@ -36,6 +39,42 @@ func RecordConformanceTest(t *testing.T, r Record) {
 		got = r.Get(0)
 		if !bytes.Equal(got, []byte("stuff")) {
 			t.Errorf("r.Get(0) = %q, want %q", got, "stuff")
+		}
+	})
+
+	t.Run("copy", func(t *testing.T) {
+		org := create()
+		org.Set(0, []byte("foo"))
+		org.Set(1, []byte("bar"))
+		org.Set(260, []byte("baz"))
+
+		cpy := org.Copy()
+
+		want := org.ToText(nil)
+		got := cpy.ToText(nil)
+
+		if !bytes.Equal(got, want) {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("copy metadata", func(t *testing.T) {
+		org := create()
+
+		orgmd := Metadata{
+			"foo": "bar",
+			"bar": 27,
+			"baz": struct{ A, b int }{2, 7},
+		}
+		org.Parse(nil, orgmd)
+
+		cpy := org.Copy()
+
+		for k, orgv := range orgmd {
+			v, ok := cpy.Meta(k)
+			if !(ok && reflect.DeepEqual(v, orgv)) {
+				t.Errorf("cpy.Meta(%q) = %+v, want %+v", k, v, orgv)
+			}
 		}
 	})
 

--- a/test_helper.go
+++ b/test_helper.go
@@ -67,9 +67,7 @@ func RecordConformanceTest(t *testing.T, create func() Record) {
 
 		cpy := org.Copy()
 
-		org.Parse(org.ToText(nil), nil)
 		want := org.ToText(nil)
-		cpy.Parse(cpy.ToText(nil), nil)
 		got := cpy.ToText(nil)
 
 		if !bytes.Equal(got, want) {

--- a/test_helper.go
+++ b/test_helper.go
@@ -54,7 +54,30 @@ func RecordConformanceTest(t *testing.T, create func() Record) {
 		got := cpy.ToText(nil)
 
 		if !bytes.Equal(got, want) {
-			t.Errorf("got %q, want %q", got, want)
+			t.Errorf("got %q\nwant %q", got, want)
+		}
+	})
+
+	t.Run("copy just parsed", func(t *testing.T) {
+		org := create()
+		org.Set(0, []byte("foo"))
+		org.Set(1, []byte("bar"))
+		org.Set(260, []byte("baz"))
+
+		text := org.ToText(nil)
+
+		// Now parse but do not call Set
+		if err := org.Parse(text, nil); err != nil {
+			t.Errorf("Parse error: %v", err)
+		}
+
+		cpy := org.Copy()
+
+		want := org.ToText(nil)
+		got := cpy.ToText(nil)
+
+		if !bytes.Equal(got, want) {
+			t.Errorf("got %q\nwant %q", got, want)
 		}
 	})
 

--- a/topology.go
+++ b/topology.go
@@ -353,7 +353,7 @@ func (t *Topology) runFilterChain() {
 
 			// Get a new record from the pool and decode the buffer into it.
 			record := t.linePool.Get().(Record)
-			err := record.Parse(line, &bakerData.Meta)
+			err := record.Parse(line, bakerData.Meta)
 			if err != nil || len(line) == 0 {
 				// Count parse errors or empty records
 				atomic.AddInt64(&t.malformed, 1)


### PR DESCRIPTION
#### :question: What

Add `Copy` method to the `Record` interface.
This is necessary for filters that want to create copies of a record.
Without that new method, one would have to call `src.ToText` followed by `dst.Parse` to make `dst` being a copy of `src` `Record`. This is what I call the naive solution.

The following benchmarks comparisons shows the optimized Copy vs the naive version:

    name                  old time/op    new time/op    delta
    LogLineCopy/set=0-8     7.94µs ± 8%    4.65µs ±10%  -41.43%  (p=0.000 n=15+15)
    LogLineCopy/set=1-8     32.7µs ± 5%    30.8µs ± 6%   -5.86%  (p=0.000 n=13+15)
    LogLineCopy/set=10-8    33.8µs ± 3%    30.6µs ± 5%   -9.56%  (p=0.000 n=14+15)
    LogLineCopy/set=20-8    32.8µs ± 6%    30.1µs ± 4%   -8.03%  (p=0.000 n=15+15)

    name                  old alloc/op   new alloc/op   delta
    LogLineCopy/set=0-8     24.5kB ± 0%    24.5kB ± 0%     ~     (all equal)
    LogLineCopy/set=1-8     39.0kB ± 0%    31.3kB ± 0%  -19.71%  (p=0.000 n=15+15)
    LogLineCopy/set=10-8    39.0kB ± 0%    31.3kB ± 0%  -19.71%  (p=0.000 n=15+15)
    LogLineCopy/set=20-8    39.3kB ± 0%    31.3kB ± 0%  -20.50%  (p=0.000 n=15+15)

    name                  old allocs/op  new allocs/op  delta
    LogLineCopy/set=0-8       3.00 ± 0%      3.00 ± 0%     ~     (all equal)
    LogLineCopy/set=1-8       6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=15+15)
    LogLineCopy/set=10-8      6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=15+15)
    LogLineCopy/set=20-8      6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=15+15)


#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
