### PR TITLE
logline.Copy didn't copy the idx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - output: remove the Files output in favor of the more generic FileWriter [#31](https://github.com/AdRoll/baker/pull/31)
 
+### Fixed
+
+- Fix a bug in `logline.Copy` [#64](https://github.com/AdRoll/baker/pull/64)
+
 ### Maintenance
 
 - input: Fixes `List` input not managing S3 "folders" [#35](https://github.com/AdRoll/baker/pull/35)

--- a/logline.go
+++ b/logline.go
@@ -238,6 +238,7 @@ func (l *LogLine) Copy() Record {
 	if l.data != nil {
 		cpy.data = make([]byte, len(l.data))
 		copy(cpy.data, l.data)
+		cpy.idx = l.idx
 	}
 	return cpy
 }

--- a/test_helper.go
+++ b/test_helper.go
@@ -97,6 +97,34 @@ func RecordConformanceTest(t *testing.T, create func() Record) {
 		}
 	})
 
+	t.Run("copy just parsed + Get", func(t *testing.T) {
+		org := create()
+		org.Set(0, []byte("foo"))
+		org.Set(1, []byte("bar"))
+		org.Set(260, []byte("baz"))
+
+		text := org.ToText(nil)
+
+		record := create()
+		if err := record.Parse(text, nil); err != nil {
+			t.Errorf("Parse error: %v", err)
+		}
+
+		cpy := record.Copy()
+
+		if !bytes.Equal(cpy.Get(0), []byte("foo")) {
+			t.Errorf("got %q, want %q", cpy.Get(0), []byte("foo"))
+		}
+
+		if !bytes.Equal(cpy.Get(1), []byte("bar")) {
+			t.Errorf("got %q, want %q", cpy.Get(1), []byte("bar"))
+		}
+
+		if !bytes.Equal(cpy.Get(260), []byte("baz")) {
+			t.Errorf("got %q, want %q", cpy.Get(260), []byte("baz"))
+		}
+	})
+
 	t.Run("copy just parsed then modified", func(t *testing.T) {
 		org := create()
 		org.Set(0, []byte("foo"))


### PR DESCRIPTION
#### :question: What

There was a bug in `logline.Copy`: when a logline were parsed and immediately copied (without setting any field), then the copy was wrong because `idx` was missing

I benchmarked the solution in this pr agains copying the whole logline (`*cpy = *l`) and this solution is a bit faster (~23000 ns/op vs ~26000 ns/op)

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
