### PR TITLE
add SupportConcurrency() to Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - output: add SQLite output [#56](https://github.com/AdRoll/baker/pull/56)
 - README: document KCL input [#59](https://github.com/AdRoll/baker/pull/59)
 - Document how to specialize baker.LogLine [#63](https://github.com/AdRoll/baker/pull/63)
+- Add `SupportConcurrency` to the `Output` interface [#72](https://github.com/AdRoll/baker/pull/72)
 
 ### Changed
 

--- a/api.go
+++ b/api.go
@@ -119,6 +119,10 @@ type Output interface {
 
 	// CanShards returns true if this output supports sharding.
 	CanShard() bool
+
+	// SupportConcurrency retrurn true if the output is able to manage
+	// multiple instances to run concurrently (procs>1)
+	SupportConcurrency() bool
 }
 
 // OutputRecord is the data structure sent to baker output components.

--- a/examples/sharding/output.go
+++ b/examples/sharding/output.go
@@ -32,6 +32,10 @@ func (s *Shardable) CanShard() bool {
 	return true
 }
 
+func (s *Shardable) SupportConcurrency() bool {
+	return true
+}
+
 func (s *Shardable) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 	// Do something with `input` record.
 	// s.idx identifies the output process index and should

--- a/input/inputtest/base.go
+++ b/input/inputtest/base.go
@@ -2,6 +2,18 @@ package inputtest
 
 import "github.com/AdRoll/baker"
 
+var BaseDesc = baker.InputDesc{
+	Name:   "Base",
+	New:    NewBase,
+	Config: &BaseConfig{},
+}
+
+type BaseConfig struct{}
+
+func NewBase(_ baker.InputParams) (baker.Input, error) {
+	return &Base{}, nil
+}
+
 // Base is a nop implementation of baker.Input useful to be embedded in tests
 // and to redeclare one or more methods.
 type Base struct{}

--- a/output/dyndb.go
+++ b/output/dyndb.go
@@ -412,3 +412,7 @@ func (b *DynamoWriter) Stats() baker.OutputStats {
 func (b *DynamoWriter) CanShard() bool {
 	return false
 }
+
+func (b *DynamoWriter) SupportConcurrency() bool {
+	return true
+}

--- a/output/filewriter.go
+++ b/output/filewriter.go
@@ -42,7 +42,7 @@ var FileWriterDesc = baker.OutputDesc{
 }
 
 type FileWriterConfig struct {
-	PathString           string        `help:"Template to describe location of the output directory: supports .Year, .Month, .Day and .Rotation. Also .Field0 if a field name has been specified in the output's fields list."`
+	PathString           string        `help:"Template to describe location of the output directory: supports .Year, .Month, .Day, .Hour, .Minute, .Second, .UUID, .Index and .Rotation. Also .Field0 if a field name has been specified in the output's fields list."`
 	RotateInterval       time.Duration `help:"Time after which data will be rotated. If -1, it will not rotate until the end." default:"60s"`
 	ZstdCompressionLevel int           `help:"zstd compression level, ranging from 1 (best speed) to 19 (best compression)." default:"3"`
 	ZstdWindowLog        int           `help:"Enable zstd long distance matching. Increase memory usage for both compressor/decompressor. If more than 27 the decompressor requires special treatment. 0:disabled." default:"0"`
@@ -125,6 +125,12 @@ func (w *FileWriter) Stats() baker.OutputStats {
 
 func (w *FileWriter) CanShard() bool {
 	return false
+}
+
+func (w *FileWriter) SupportConcurrency() bool {
+	// .Index and .UUID are unique to the output process, so if the file path
+	// includes them, we know that there won't be name clashes
+	return strings.Contains(w.Cfg.PathString, "{{.Index}}") || strings.Contains(w.Cfg.PathString, "{{.UUID}}")
 }
 
 func (cfg *FileWriterConfig) fillDefaults() {

--- a/output/nop.go
+++ b/output/nop.go
@@ -21,7 +21,8 @@ func NewNopWriter(cfg baker.OutputParams) (baker.Output, error) {
 	return &NopWriter{}, nil
 }
 
-func (b *NopWriter) CanShard() bool { return true }
+func (b *NopWriter) CanShard() bool           { return true }
+func (b *NopWriter) SupportConcurrency() bool { return true }
 
 func (nop *NopWriter) Run(input <-chan baker.OutputRecord, upch chan<- string) error {
 	for range input {

--- a/output/oplog.go
+++ b/output/oplog.go
@@ -60,3 +60,7 @@ func (w *OpLog) Stats() baker.OutputStats {
 func (b *OpLog) CanShard() bool {
 	return false
 }
+
+func (b *OpLog) SupportConcurrency() bool {
+	return true
+}

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,0 +1,80 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/AdRoll/baker"
+	"github.com/AdRoll/baker/input/inputtest"
+	"github.com/AdRoll/baker/output/outputtest"
+)
+
+func TestNewTopologyFromConfig_out_concurrency(t *testing.T) {
+	const src = `
+[input]
+name="Base"
+
+[output]
+name="Base"
+procs=%d
+[output.config]
+SupportConcurrency = %t
+`
+
+	tests := []struct {
+		name               string
+		procs              int
+		supportConcurrency bool
+		wantErr            bool
+	}{
+		{
+			name:               "no concurrency, 1 proc",
+			procs:              1,
+			supportConcurrency: false,
+			wantErr:            false,
+		},
+		{
+			name:               "concurrency, 1 proc",
+			procs:              1,
+			supportConcurrency: true,
+			wantErr:            false,
+		},
+		{
+			name:               "no concurrency, 2 procs",
+			procs:              2,
+			supportConcurrency: false,
+			wantErr:            true,
+		},
+		{
+			name:               "concurrency, 2 procs",
+			procs:              2,
+			supportConcurrency: true,
+			wantErr:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			toml := fmt.Sprintf(src, tt.procs, tt.supportConcurrency)
+
+			components := baker.Components{
+				Inputs:      []baker.InputDesc{inputtest.BaseDesc},
+				Filters:     []baker.FilterDesc{},
+				Outputs:     []baker.OutputDesc{outputtest.BaseDesc},
+				FieldByName: func(name string) (baker.FieldIndex, bool) { return 0, true },
+				Validate:    func(baker.Record) (bool, baker.FieldIndex) { return true, 0 },
+			}
+
+			cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), components)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = baker.NewTopologyFromConfig(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/output/outputtest/base.go
+++ b/output/outputtest/base.go
@@ -2,10 +2,34 @@ package outputtest
 
 import "github.com/AdRoll/baker"
 
+var BaseDesc = baker.OutputDesc{
+	Name:   "Base",
+	New:    NewBase,
+	Config: &BaseConfig{},
+	Raw:    true,
+}
+
+type BaseConfig struct {
+	SupportConcurrency bool `help:"Add concurrency support" default:"false"`
+}
+
 // Base is a nop implementation of baker.Output useful to be embedded in tests
 // and to redeclare one or more methods.
-type Base struct{}
+type Base struct {
+	supportConcurrency bool
+}
+
+func NewBase(cfg baker.OutputParams) (baker.Output, error) {
+	return &Base{
+		supportConcurrency: cfg.DecodedConfig.(*BaseConfig).SupportConcurrency,
+	}, nil
+}
 
 func (Base) Run(_ <-chan baker.OutputRecord, _ chan<- string) error { return nil }
 func (Base) CanShard() bool                                         { return false }
-func (Base) Stats() baker.OutputStats                               { return baker.OutputStats{} }
+
+func (b *Base) SupportConcurrency() bool {
+	return b.supportConcurrency
+}
+
+func (Base) Stats() baker.OutputStats { return baker.OutputStats{} }

--- a/output/outputtest/recorder.go
+++ b/output/outputtest/recorder.go
@@ -44,4 +44,5 @@ func (r *Recorder) Run(input <-chan baker.OutputRecord, _ chan<- string) error {
 func (r *Recorder) Stats() baker.OutputStats { return baker.OutputStats{} }
 
 // CanShard implements baker.Output interface.
-func (r *Recorder) CanShard() bool { return true }
+func (r *Recorder) CanShard() bool           { return true }
+func (r *Recorder) SupportConcurrency() bool { return true }

--- a/output/sqlite.go
+++ b/output/sqlite.go
@@ -408,5 +408,15 @@ func (c *SQLiteWriter) Stats() baker.OutputStats {
 }
 
 func (c *SQLiteWriter) CanShard() bool {
-	return true
+	// github.com/mattn/go-sqlite3 supports concurrency only for reading,
+	// so the output isn't concurrent-safe and it supports sharding
+	// only with different file names
+	return strings.Contains(c.cfg.PathString, "{{.ShardId}}")
+}
+
+func (c *SQLiteWriter) SupportConcurrency() bool {
+	// github.com/mattn/go-sqlite3 supports concurrency only for reading,
+	// so the output isn't concurrent-safe and it supports "concurrency"
+	// only with different file names
+	return strings.Contains(c.cfg.PathString, "{{.ShardId}}")
 }

--- a/output/stats.go
+++ b/output/stats.go
@@ -347,4 +347,5 @@ func (s *Stats) Stats() baker.OutputStats {
 }
 
 // CanShard implements baker.Output
-func (s *Stats) CanShard() bool { return true }
+func (s *Stats) CanShard() bool           { return false }
+func (s *Stats) SupportConcurrency() bool { return false }

--- a/output/websocket.go
+++ b/output/websocket.go
@@ -78,3 +78,7 @@ func (w *WebSocketWriter) Stats() baker.OutputStats {
 func (b *WebSocketWriter) CanShard() bool {
 	return false
 }
+
+func (b *WebSocketWriter) SupportConcurrency() bool {
+	return true
+}

--- a/record.go
+++ b/record.go
@@ -24,7 +24,7 @@ type Record interface {
 	//
 	// The copied record could have been obtained by:
 	//  var dst Record
-	//  src.Parse(dst.ToText(), nil)
+	//  dst.Parse(src.ToText(), nil)
 	//
 	// but Record implementations should provide a more efficient way.
 	Copy() Record

--- a/topology.go
+++ b/topology.go
@@ -142,6 +142,10 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error creating output: %v", err)
 		}
+		if cfg.Output.Procs > 1 && !out.SupportConcurrency() {
+			return nil, fmt.Errorf("procs>1 used with output unable to support concurrency")
+		}
+
 		tp.Output = append(tp.Output, out)
 	}
 

--- a/upload/s3_integration_test.go
+++ b/upload/s3_integration_test.go
@@ -32,6 +32,7 @@ func nthFile(n int) string { return fmt.Sprintf("file.%02d", n) }
 
 func (o *customOutput) Stats() baker.OutputStats { return baker.OutputStats{} }
 func (o *customOutput) CanShard() bool           { return false }
+func (o *customOutput) SupportConcurrency() bool { return false }
 
 func (o *customOutput) Run(in <-chan baker.OutputRecord, upch chan<- string) error {
 	// Simulate a new file for each received record
@@ -56,14 +57,14 @@ func testIntegrationS3(callStop bool) func(t *testing.T) {
 		toml := `
 		[input]
 		name="records"
-	
+
 		[output]
 		name="custom"
 		procs=1
-	
+
 		[upload]
 		name="s3"
-	
+
 			[upload.config]
 			sourcebasepath=%q
 			stagingpath=%q


### PR DESCRIPTION
#### :question: What

Add `SupportConcurrency() bool` to the `Output` interface and checks while building the topology that `procs>1` isn't used
with an output unable to support it

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
