### PR TITLE
improve help output for docs pages

### DIFF
--- a/help_config.go
+++ b/help_config.go
@@ -161,6 +161,9 @@ func newHelpConfigKeyFromField(f reflect.StructField) (helpConfigKey, error) {
 		switch f.Type.Elem().Kind() {
 		case reflect.String:
 			h.typ = "array of strings"
+			if h.def == "" {
+				h.def = "[]"
+			}
 		case reflect.Int:
 			h.typ = "array of ints"
 		default:

--- a/help_markdown.go
+++ b/help_markdown.go
@@ -122,10 +122,9 @@ func GenerateMarkdownHelp(w io.Writer, desc interface{}) error {
 
 func breakAfterDots(s string) string {
 	r := strings.NewReplacer(
-		".", ".\n",
-		"!", "!\n",
-		"?", "?\n",
-		":", ":\n",
+		".", ".  \n",
+		"!", "!  \n",
+		"?", "?  \n",
 	)
 	return r.Replace(s)
 }
@@ -216,7 +215,7 @@ func genMetricsMarkdown(w io.Writer, doc metricsDoc) {
 
 func genConfigKeysMarkdown(w io.Writer, keys []helpConfigKey) {
 	fmt.Fprintln(w, "|Name|Type|Default|Required|Description|")
-	fmt.Fprintln(w, "|:--:|:--:|:-----:|:------:|:---------:|")
+	fmt.Fprintln(w, "|----|:--:|:-----:|:------:|-----------|")
 	for _, k := range keys {
 		fmt.Fprintf(w, "| %v| %v| %v| %t| %v|\n", k.name, k.typ, k.def, k.required, k.desc)
 	}


### PR DESCRIPTION
#### :question: What

3 things here to optimize the markdown output when generating the components' pages for the doc site:

* prints the slice default when missing as it is often used into the already existing components (to have the same behavior)
* add double space to make a newline, as the website doesn't show a newline with only `\n`. Also, don't add a newline after `:` because in the website it creates an odd output in lists
* do not align to the center of the columns the name and the description, for a more readable output