### PR TITLE
Read field mapping from toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Document how to specialize baker.LogLine [#63](https://github.com/AdRoll/baker/pull/63)
 - Add `baker.MainCLI` [#73](https://github.com/AdRoll/baker/pull/73)
 - Implement markdown rendering of component help/configuration [#80](https://github.com/AdRoll/baker/pull/80)
+- Add `[fields]` section in TOML in which use can define field indexes <-> names mapping [#84](https://github.com/AdRoll/baker/pull/84)
 
 ### Changed
 

--- a/baker_cli.go
+++ b/baker_cli.go
@@ -67,7 +67,7 @@ func MainCLI(components Components) error {
 	}
 
 	if *flagVerbose && *flagQuiet {
-		return fmt.Errorf("logging can't both be verbose and quiet!")
+		return fmt.Errorf("logging can't both be verbose and quiet")
 	}
 
 	if *flagVerbose {

--- a/config.go
+++ b/config.go
@@ -399,12 +399,14 @@ func NewConfigFromToml(f io.Reader, comp Components) (*Config, error) {
 		return nil, fmt.Errorf("invalid keys in configuration file: %v", keys)
 	}
 
+	if err := assignFieldMapping(&cfg, comp); err != nil {
+		return nil, err
+	}
+
 	// Copy pluggable functions
 	cfg.shardingFuncs = comp.ShardingFuncs
 	cfg.validate = comp.Validate
 	cfg.createRecord = comp.CreateRecord
-	cfg.fieldByName = comp.FieldByName
-	cfg.fieldName = comp.FieldName
 
 	// Fill-in with missing defaults
 	return &cfg, cfg.fillDefaults()
@@ -414,6 +416,51 @@ func NewConfigFromToml(f io.Reader, comp Components) (*Config, error) {
 func hasConfig(cfg interface{}) bool {
 	tf := reflect.TypeOf(cfg).Elem()
 	return tf.NumField() != 0
+}
+
+// assignFieldMapping verifies that field mapping has been set once, but only
+// once (either in cfg or comp). Then if that is the case, assignFieldMapping
+// sets both fieldByName and fieldName in cfg.
+func assignFieldMapping(cfg *Config, comp Components) error {
+	// First, get inconsistent cases out of the way.
+	if len(cfg.Fields.Names) == 0 && comp.FieldByName == nil && comp.FieldName == nil {
+		return fmt.Errorf("field indexes/names have not been set")
+	}
+
+	if (comp.FieldByName == nil) != (comp.FieldName == nil) {
+		return fmt.Errorf("FieldByName and FieldName must be either both set or both unset")
+	}
+
+	if len(cfg.Fields.Names) != 0 && comp.FieldByName != nil && comp.FieldName != nil {
+		return fmt.Errorf("field indexes/names can't both be set in TOML and in Components")
+	}
+
+	if comp.FieldByName != nil && comp.FieldName != nil {
+		// Ok, mapping has been set from Components.
+		cfg.fieldByName = comp.FieldByName
+		cfg.fieldName = comp.FieldName
+		return nil
+	}
+
+	// Mapping has been set from Config, create both closures and assign them.
+	m := make(map[string]FieldIndex, len(cfg.Fields.Names))
+	for f, s := range cfg.Fields.Names {
+		_, ok := m[s]
+		if ok {
+			return fmt.Errorf("duplicated field name %q", s)
+		}
+		m[s] = FieldIndex(f)
+	}
+
+	cfg.fieldByName = func(name string) (FieldIndex, bool) {
+		f, ok := m[name]
+		return f, ok
+	}
+	cfg.fieldName = func(fidx FieldIndex) string {
+		return cfg.Fields.Names[fidx]
+	}
+
+	return nil
 }
 
 // RequiredFields returns the names of the underlying configuration structure

--- a/config.go
+++ b/config.go
@@ -111,6 +111,14 @@ type ConfigMetrics struct {
 	desc   *MetricsDesc
 }
 
+// ConfigFields specifies names for records fields. In addition of being a list
+// of names, the position of each name in the slice also indicates the FieldIndex
+// for that name. In other words, if Names[0] = "address", then a FieldIndex of
+// 0 is that field, and "address" is the name of that field.
+type ConfigFields struct {
+	Names []string
+}
+
 // A Config specifies the configuration for a topology.
 type Config struct {
 	Input       ConfigInput
@@ -118,10 +126,12 @@ type Config struct {
 	Filter      []ConfigFilter
 	Output      ConfigOutput
 	Upload      ConfigUpload
-	General     ConfigGeneral
-	Metrics     ConfigMetrics
-	User        []ConfigUser
-	CSV         ConfigCSV
+
+	General ConfigGeneral
+	Fields  ConfigFields
+	Metrics ConfigMetrics
+	CSV     ConfigCSV
+	User    []ConfigUser
 
 	shardingFuncs map[FieldIndex]ShardingFunc
 	validate      ValidationFunc

--- a/config.go
+++ b/config.go
@@ -422,20 +422,23 @@ func hasConfig(cfg interface{}) bool {
 // once (either in cfg or comp). Then if that is the case, assignFieldMapping
 // sets both fieldByName and fieldName in cfg.
 func assignFieldMapping(cfg *Config, comp Components) error {
-	// First, get inconsistent cases out of the way.
-	if len(cfg.Fields.Names) == 0 && comp.FieldByName == nil && comp.FieldName == nil {
-		return fmt.Errorf("field indexes/names have not been set")
-	}
+	cfgOk := len(cfg.Fields.Names) != 0
+	compOk := comp.FieldByName != nil && comp.FieldName != nil
 
 	if (comp.FieldByName == nil) != (comp.FieldName == nil) {
 		return fmt.Errorf("FieldByName and FieldName must be either both set or both unset")
 	}
 
-	if len(cfg.Fields.Names) != 0 && comp.FieldByName != nil && comp.FieldName != nil {
+	// First, get inconsistent cases out of the way.
+	if !cfgOk && !compOk {
+		return fmt.Errorf("field indexes/names have not been set")
+	}
+
+	if cfgOk && compOk {
 		return fmt.Errorf("field indexes/names can't both be set in TOML and in Components")
 	}
 
-	if comp.FieldByName != nil && comp.FieldName != nil {
+	if compOk {
 		// Ok, mapping has been set from Components.
 		cfg.fieldByName = comp.FieldByName
 		cfg.fieldName = comp.FieldName

--- a/config_test.go
+++ b/config_test.go
@@ -101,3 +101,128 @@ func TestEnvVarBaseReplace(t *testing.T) {
 		t.Fatalf("wrong toml: %s", string(buf))
 	}
 }
+
+func Test_assignFieldMapping(t *testing.T) {
+	fieldName := func(f FieldIndex) string {
+		switch f {
+		case 0:
+			return "name0"
+		case 1:
+			return "name1"
+		}
+		return ""
+	}
+
+	fieldByName := func(n string) (FieldIndex, bool) {
+		switch n {
+		case "name0":
+			return 0, true
+		case "name1":
+			return 1, true
+		}
+		return 0, false
+	}
+
+	cfgFields := ConfigFields{
+		Names: []string{"name0", "name1"},
+	}
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		comp    Components
+		wantErr bool
+	}{
+		{
+			name: "only in Config",
+			cfg: &Config{
+				Fields: cfgFields,
+			},
+		},
+		{
+			name: "only in Components",
+			cfg:  &Config{},
+			comp: Components{
+				FieldByName: fieldByName,
+				FieldName:   fieldName,
+			},
+		},
+
+		// error cases
+		{
+			name: "nothing set",
+			cfg:  &Config{}, comp: Components{},
+			wantErr: true,
+		},
+		{
+			name: "FieldByName but not FieldName",
+			cfg:  &Config{},
+			comp: Components{
+				FieldByName: fieldByName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "FieldName but not FieldByName",
+			cfg:  &Config{},
+			comp: Components{
+				FieldName: fieldName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "mapping set both in Config and Components",
+			cfg: &Config{
+				Fields: cfgFields,
+			},
+			comp: Components{
+				FieldByName: fieldByName,
+				FieldName:   fieldName,
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicated field name",
+			cfg: &Config{
+				Fields: ConfigFields{
+					Names: []string{"foo", "bar", "baz", "baz"},
+				},
+			},
+			comp: Components{
+				FieldByName: fieldByName,
+				FieldName:   fieldName,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := assignFieldMapping(tt.cfg, tt.comp); (err != nil) != tt.wantErr {
+				t.Errorf("assignFieldMapping() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// Now we check that fieldByName has been set correctly.
+			if field, ok := tt.cfg.fieldByName("name0"); field != 0 || !ok {
+				t.Errorf(`cfg.fieldByName("name0") = %v,%v, want %v,%v`, field, ok, 0, true)
+			}
+			if field, ok := tt.cfg.fieldByName("name1"); field != 1 || !ok {
+				t.Errorf(`cfg.fieldByName("name1") = %v,%v, want %v,%v`, field, ok, 1, true)
+			}
+			if field, ok := tt.cfg.fieldByName("do-no-exist"); ok {
+				t.Errorf(`cfg.fieldByName("do-no-exist") = %v,%v, want %v,%v`, field, ok, 0, false)
+			}
+
+			// Now we check that fieldName has been set correctly.
+			if name := tt.cfg.fieldName(0); name != "name0" {
+				t.Errorf(`cfg.fieldName(0) = %q, want %q`, name, "name0")
+			}
+			if name := tt.cfg.fieldName(1); name != "name1" {
+				t.Errorf(`cfg.fieldName(1) = %q, want %q`, name, "name1")
+			}
+		})
+	}
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -57,7 +57,6 @@ procs=1
 		Inputs:  input.All,
 		Outputs: output.All,
 		Filters: filter.All,
-		// FieldByName: fieldByName,
 	}
 	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), c)
 	if err != nil {

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/AdRoll/baker"
+	"github.com/AdRoll/baker/filter"
 	"github.com/AdRoll/baker/input"
 	"github.com/AdRoll/baker/output"
 )
@@ -37,6 +38,14 @@ name = "List"
 	[input.config]
 	files=["testdata/input.csv.zst"]
 
+[fields]
+names=["timestamp", "source", "target"]
+
+[[filter]]
+name="ReplaceFields"
+	[filter.config]
+	ReplaceFields=["replaced", "timestamp"]
+
 [output]
 name = "FileWriter"
 procs=1
@@ -45,9 +54,10 @@ procs=1
 	PathString="./_out/output.csv.gz"
 `
 	c := baker.Components{
-		Inputs:      input.All,
-		Outputs:     output.All,
-		FieldByName: fieldByName,
+		Inputs:  input.All,
+		Outputs: output.All,
+		Filters: filter.All,
+		// FieldByName: fieldByName,
 	}
 	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), c)
 	if err != nil {

--- a/examples/sharding/main.go
+++ b/examples/sharding/main.go
@@ -30,19 +30,28 @@ const (
 	Dollar    baker.FieldIndex = 6
 )
 
-var fields = map[string]baker.FieldIndex{
-	"id":         ID,
-	"first_name": FirstName,
-	"last_name":  LastName,
-	"age":        Age,
-	"street":     Street,
-	"city":       City,
-	"dollar":     Dollar,
+var fieldNames = [...]string{
+	"id",
+	"first_name",
+	"last_name",
+	"age",
+	"street",
+	"city",
+	"dollar",
 }
 
-func fieldByName(key string) (baker.FieldIndex, bool) {
-	idx, ok := fields[key]
-	return idx, ok
+func fieldByName(name string) (baker.FieldIndex, bool) {
+	for idx, fname := range fieldNames {
+		if name == fname {
+			return baker.FieldIndex(idx), true
+		}
+	}
+
+	return 0, false
+}
+
+func fieldName(idx baker.FieldIndex) string {
+	return fieldNames[idx]
 }
 
 var components = baker.Components{
@@ -50,6 +59,7 @@ var components = baker.Components{
 	Outputs:       []baker.OutputDesc{ShardableDesc},
 	ShardingFuncs: shardingFuncs,
 	FieldByName:   fieldByName,
+	FieldName:     fieldName,
 }
 
 func main() {

--- a/input/tcp_test.go
+++ b/input/tcp_test.go
@@ -17,6 +17,9 @@ import (
 // received by the output.
 func TestTCP1by1(t *testing.T) {
 	toml := `
+	[fields]
+	names = ["f0", "f1", "f2"]
+
 	[input]
 	name="TCP"
 
@@ -97,6 +100,9 @@ func TestTCP1by1(t *testing.T) {
 // received by the output.
 func TestTCPChunks(t *testing.T) {
 	toml := `
+	[fields]
+	names = ["f0", "f1", "f2"]
+
 	[input]
 	name="TCP"
 
@@ -187,6 +193,9 @@ func TestTCPChunks(t *testing.T) {
 // correctly).
 func TestTCPStopChunk(t *testing.T) {
 	toml := `
+	[fields]
+	names = ["f0", "f1", "f2"]
+
 	[input]
 	name="TCP"
 

--- a/raw_output_test.go
+++ b/raw_output_test.go
@@ -12,6 +12,9 @@ import (
 func TestRawOutputFields(t *testing.T) {
 
 	toml := `
+[fields]
+names=["field0", "field1", "field2", "field3"]
+	
 [input]
 name="Records"
 
@@ -23,20 +26,6 @@ fields=["field2", "field0", "field1", "field3"]
 	c := baker.Components{
 		Inputs:  []baker.InputDesc{inputtest.RecordsDesc},
 		Outputs: []baker.OutputDesc{outputtest.RecorderDesc},
-		FieldByName: func(name string) (baker.FieldIndex, bool) {
-			switch name {
-			case "field0":
-				return 0, true
-			case "field1":
-				return 1, true
-			case "field2":
-				return 2, true
-			case "field3":
-				return 3, true
-			default:
-				return 0, false
-			}
-		},
 	}
 
 	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), c)

--- a/topology.go
+++ b/topology.go
@@ -118,11 +118,11 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 	}
 
 	for _, fname := range cfg.Output.Fields {
-		if fidx, ok := cfg.fieldByName(fname); !ok {
+		fidx, ok := cfg.fieldByName(fname)
+		if !ok {
 			return nil, fmt.Errorf("error creating output: unknown field: %q", fname)
-		} else {
-			tp.outFields = append(tp.outFields, fidx)
 		}
+		tp.outFields = append(tp.outFields, fidx)
 	}
 
 	for i := 0; i < cfg.Output.Procs; i++ {

--- a/upload/s3_integration_test.go
+++ b/upload/s3_integration_test.go
@@ -54,23 +54,26 @@ func testIntegrationS3(callStop bool) func(t *testing.T) {
 		defer testutil.DisableLogging()()
 
 		toml := `
-		[input]
-		name="records"
-	
-		[output]
-		name="custom"
-		procs=1
-	
-		[upload]
-		name="s3"
-	
-			[upload.config]
-			sourcebasepath=%q
-			stagingpath=%q
-			bucket="my-bucket"
-			interval="10ms"
-			retries=1
-			concurrency=1`
+[fields]
+names=["f0", "f1", "f2", "f3"]
+
+[input]
+name="records"
+
+[output]
+name="custom"
+procs=1
+
+[upload]
+name="s3"
+
+	[upload.config]
+	sourcebasepath=%q
+	stagingpath=%q
+	bucket="my-bucket"
+	interval="10ms"
+	retries=1
+	concurrency=1`
 
 		/* Configure the pipeline */
 
@@ -157,7 +160,7 @@ func TestIntegrationS3(t *testing.T) {
 	// exits).
 	//
 	// The topology should end by itself without any error, we also checks that
-	t.Run("topololy.wait", testIntegrationS3(false))
+	t.Run("topology.wait", testIntegrationS3(false))
 
 	// the expected number of files have been uploaded to their expected bucket/key.
 	// On the second subtest we immeditately stop the topology after starting it,
@@ -166,5 +169,5 @@ func TestIntegrationS3(t *testing.T) {
 	//  - all records have been processed,
 	//  - all files have been written by the output
 	//  - all files have been uplodaed by the S3 upload
-	t.Run("topololy.stop", testIntegrationS3(true))
+	t.Run("topology.stop", testIntegrationS3(true))
 }

--- a/user_config_test.go
+++ b/user_config_test.go
@@ -14,6 +14,9 @@ func fillComponentsAndLoadConfig(t *testing.T, toml string, user ...baker.UserDe
 	t.Helper()
 
 	const base = `
+[fields]
+names=["f0", "f1", "f2", "f3"]	
+
 [input]
 name="random"
 


### PR DESCRIPTION
#### :question: What

This is another step in the direction of making baker a full-featured binary one can use without touching code.
This gives the possibilty to defined field mapping in TOML. What we call fIeld mapping is a two-way mapping from field indexes and field names.  
Before this change, one had to provide 2 function `FieldName` and `FieldByName` into baker.Components, even for super basic use of baker. Now you can specify this in TOML, from which 2 closures are generated and assigned into these 2 functions. This is done in `NewConfigFromTOML`.

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
