### PR TITLE
Enable custom field separator usage

### DIFF
--- a/config.go
+++ b/config.go
@@ -165,7 +165,9 @@ func (c *Config) fillDefaults() error {
 }
 
 func (c *Config) fillCreateRecordDefault() error {
-	if c.createRecord == nil {
+	// For now a custom field separator will have precedence over the
+	// default createRecord function.
+	if c.createRecord == nil || c.CSV.FieldSeparator != "" {
 		fieldSeparator := DefaultLogLineFieldSeparator
 		if c.CSV.FieldSeparator != "" {
 			sep := []rune(c.CSV.FieldSeparator)


### PR DESCRIPTION
#### :question: What

Actually enable usage of a custom field separator, this [line of code](https://github.com/AdRoll/baker/blob/a541e0da98f5e6bcce8f1d43b58143c58847e3a7/config.go#L411) in `config.go` always set the `createRecord` function which doesn't allows the usage of a custom field separator.

#### :hammer: How to test

1. Run `make test` in root dir.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [X] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [X] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [ ] Has `make gofmt-write` been run on the code?
- [ ] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
