### PR TITLE
Replace FieldName function to Fieldname slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove datadog-specific code from [general] section. Instead add [metrics] which can be extended with baker.MetricsClient interfaces. [#34](https://github.com/AdRoll/baker/pull/34)
 - Remove duration parameter from baker.Main [#62](https://github.com/AdRoll/baker/pull/62)
 - TimestampRange filter accepts 'now' as range [#106](https://github.com/AdRoll/baker/pull/106)
-- standardize the components' structs names [#105](https://github.com/AdRoll/baker/pull/105)
+- Standardize the components' structs names [#105](https://github.com/AdRoll/baker/pull/105)
+- **Breaking** Change func FieldName to FieldNames (slice) as it allows to know the number of defined fields [#110](https://github.com/AdRoll/baker/pull/110)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -84,21 +84,21 @@ parsing a toml file with `baker.NewConfigFromToml()`. This function requires a
 This is an example of this struct:
 
 ```go
-baker.Components{
-    Inputs:        input.AllInputs(),
-    Filters:       MyCustomFilters(),
-    // merge available outputs with user custom outputs
-    Outputs:       append(output.AllOutputs(), MyCustomOutputs()...),
-    Uploads:       MyCustomUploads(),
-    // optional: custom extra config
-    User:          MyCustomConfigs(),
-    // optional: used if sharding is enabled
-    ShardingFuncs: MyRecordShardingFuncs,
-    // optional: used if records must be validated. Not used if [general.dont_validate_fields] is used in TOML
-    Validate:      MyRecordValidationFunc,
-    // optional: functions to get fields indexes by name and vice-versa
-    FieldByName:   MyFieldByNameFunc,
-    FieldName:     MyFieldNameFunc,
+comp := baker.Components{
+	Inputs:  input.AllInputs(),
+	Filters: MyCustomFilters(),
+	// merge available outputs with user custom outputs
+	Outputs: append(output.AllOutputs(), MyCustomOutputs()...),
+	Uploads: MyCustomUploads(),
+	// optional: custom extra config
+	User: MyCustomConfigs(),
+	// optional: used if sharding is enabled
+	ShardingFuncs: MyRecordShardingFuncs,
+	// optional: used if records must be validated. Not used if [general.dont_validate_fields] is used in TOML
+	Validate: MyRecordValidationFunc,
+	// optional: functions to get fields indexes by name and vice-versa
+	FieldByName: MyFieldByNameFunc,
+	FieldNames:  []string{"field0", "field1", "field2"},
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -138,7 +138,7 @@ type Config struct {
 	createRecord  func() Record
 
 	fieldByName func(string) (FieldIndex, bool)
-	fieldName   func(FieldIndex) string
+	fieldNames  []string
 }
 
 // String returns a string representation of the exported fields of c.
@@ -423,9 +423,9 @@ func hasConfig(cfg interface{}) bool {
 // sets both fieldByName and fieldName in cfg.
 func assignFieldMapping(cfg *Config, comp Components) error {
 	cfgOk := len(cfg.Fields.Names) != 0
-	compOk := comp.FieldByName != nil && comp.FieldName != nil
+	compOk := comp.FieldByName != nil && comp.FieldNames != nil
 
-	if (comp.FieldByName == nil) != (comp.FieldName == nil) {
+	if (comp.FieldByName == nil) != (comp.FieldNames == nil) {
 		return fmt.Errorf("FieldByName and FieldName must be either both set or both unset")
 	}
 
@@ -441,7 +441,7 @@ func assignFieldMapping(cfg *Config, comp Components) error {
 	if compOk {
 		// Ok, mapping has been set from Components.
 		cfg.fieldByName = comp.FieldByName
-		cfg.fieldName = comp.FieldName
+		cfg.fieldNames = comp.FieldNames
 		return nil
 	}
 
@@ -455,12 +455,10 @@ func assignFieldMapping(cfg *Config, comp Components) error {
 		m[s] = FieldIndex(f)
 	}
 
+	cfg.fieldNames = cfg.Fields.Names
 	cfg.fieldByName = func(name string) (FieldIndex, bool) {
 		f, ok := m[name]
 		return f, ok
-	}
-	cfg.fieldName = func(fidx FieldIndex) string {
-		return cfg.Fields.Names[fidx]
 	}
 
 	return nil

--- a/config_test.go
+++ b/config_test.go
@@ -103,23 +103,14 @@ func TestEnvVarBaseReplace(t *testing.T) {
 }
 
 func Test_assignFieldMapping(t *testing.T) {
-	fieldName := func(f FieldIndex) string {
-		switch f {
-		case 0:
-			return "name0"
-		case 1:
-			return "name1"
-		}
-		return ""
-	}
-
+	fieldNames := []string{"name0", "name1"}
 	fieldByName := func(n string) (FieldIndex, bool) {
-		switch n {
-		case "name0":
-			return 0, true
-		case "name1":
-			return 1, true
+		for idx, name := range fieldNames {
+			if n == name {
+				return FieldIndex(idx), true
+			}
 		}
+
 		return 0, false
 	}
 
@@ -144,7 +135,7 @@ func Test_assignFieldMapping(t *testing.T) {
 			cfg:  &Config{},
 			comp: Components{
 				FieldByName: fieldByName,
-				FieldName:   fieldName,
+				FieldNames:  fieldNames,
 			},
 		},
 
@@ -166,7 +157,7 @@ func Test_assignFieldMapping(t *testing.T) {
 			name: "FieldName but not FieldByName",
 			cfg:  &Config{},
 			comp: Components{
-				FieldName: fieldName,
+				FieldNames: fieldNames,
 			},
 			wantErr: true,
 		},
@@ -177,7 +168,7 @@ func Test_assignFieldMapping(t *testing.T) {
 			},
 			comp: Components{
 				FieldByName: fieldByName,
-				FieldName:   fieldName,
+				FieldNames:  fieldNames,
 			},
 			wantErr: true,
 		},
@@ -190,7 +181,7 @@ func Test_assignFieldMapping(t *testing.T) {
 			},
 			comp: Components{
 				FieldByName: fieldByName,
-				FieldName:   fieldName,
+				FieldNames:  fieldNames,
 			},
 			wantErr: true,
 		},
@@ -217,11 +208,11 @@ func Test_assignFieldMapping(t *testing.T) {
 			}
 
 			// Now we check that fieldName has been set correctly.
-			if name := tt.cfg.fieldName(0); name != "name0" {
-				t.Errorf(`cfg.fieldName(0) = %q, want %q`, name, "name0")
+			if name := tt.cfg.fieldNames[0]; name != "name0" {
+				t.Errorf(`cfg.fieldNames[0] = %q, want %q`, name, "name0")
 			}
-			if name := tt.cfg.fieldName(1); name != "name1" {
-				t.Errorf(`cfg.fieldName(1) = %q, want %q`, name, "name1")
+			if name := tt.cfg.fieldNames[1]; name != "name1" {
+				t.Errorf(`cfg.fieldNames[1] = %q, want %q`, name, "name1")
 			}
 		})
 	}

--- a/desc.go
+++ b/desc.go
@@ -16,7 +16,7 @@ type Components struct {
 	CreateRecord  func() Record               // CreateRecord creates a new record
 
 	FieldByName func(string) (FieldIndex, bool) // FieldByName gets a field index by its name
-	FieldName   func(FieldIndex) string         // FieldName gets a field name by its index
+	FieldNames  []string                        // FieldNames holds field names, indexed by their FieldIndex
 }
 
 // ComponentParams holds the common configuration parameters passed to components of all kinds.
@@ -24,7 +24,7 @@ type ComponentParams struct {
 	DecodedConfig  interface{}                     // decoded component-specific struct (from configuration file)
 	CreateRecord   func() Record                   // factory function to create new empty records
 	FieldByName    func(string) (FieldIndex, bool) // translates field names to Record indexes
-	FieldName      func(FieldIndex) string         // returns the name of a field given its index in the Record
+	FieldNames     []string                        // FieldNames holds field names, indexed by their FieldIndex
 	ValidateRecord ValidationFunc                  // function to validate a record
 	Metrics        MetricsClient                   // Metrics allows components to add code instrumentation and have metrics exported to the configured backend, if any?
 }

--- a/examples/advanced/main.go
+++ b/examples/advanced/main.go
@@ -25,6 +25,9 @@ const (
 	Target    baker.FieldIndex = 2
 )
 
+// And their respective names
+var fieldNames = []string{"timestamp", "source", "target"}
+
 var components = baker.Components{
 	Inputs:        input.All,
 	Filters:       filter.All,
@@ -33,13 +36,7 @@ var components = baker.Components{
 	ShardingFuncs: shardingFuncs,
 	Validate:      validateLogLine,
 	FieldByName:   fieldByName,
-	FieldName:     fieldName,
-}
-
-var fields = map[string]baker.FieldIndex{
-	"timestamp": Timestamp,
-	"source":    Source,
-	"target":    Target,
+	FieldNames:    fieldNames,
 }
 
 var shardingFuncs = map[baker.FieldIndex]baker.ShardingFunc{
@@ -71,16 +68,12 @@ func validateLogLine(baker.Record) (bool, baker.FieldIndex) {
 	return true, 0
 }
 
-func fieldByName(key string) (baker.FieldIndex, bool) {
-	idx, ok := fields[key]
-	return idx, ok
-}
-
-func fieldName(idx baker.FieldIndex) string {
-	for k, v := range fields {
-		if v == idx {
-			return k
+func fieldByName(name string) (baker.FieldIndex, bool) {
+	for idx, n := range fieldNames {
+		if n == name {
+			return baker.FieldIndex(idx), true
 		}
 	}
-	return ""
+
+	return 0, false
 }

--- a/examples/sharding/main.go
+++ b/examples/sharding/main.go
@@ -30,7 +30,8 @@ const (
 	Dollar    baker.FieldIndex = 6
 )
 
-var fieldNames = [...]string{
+// And their respective names
+var fieldNames = []string{
 	"id",
 	"first_name",
 	"last_name",
@@ -50,16 +51,12 @@ func fieldByName(name string) (baker.FieldIndex, bool) {
 	return 0, false
 }
 
-func fieldName(idx baker.FieldIndex) string {
-	return fieldNames[idx]
-}
-
 var components = baker.Components{
 	Inputs:        input.All,
 	Outputs:       []baker.OutputDesc{ShardableDesc},
 	ShardingFuncs: shardingFuncs,
 	FieldByName:   fieldByName,
-	FieldName:     fieldName,
+	FieldNames:    fieldNames,
 }
 
 func main() {

--- a/output/sqlite.go
+++ b/output/sqlite.go
@@ -146,7 +146,7 @@ func NewSQLite(isRaw bool) func(baker.OutputParams) (baker.Output, error) {
 		// an SQL table in the SQLite file.
 		var fieldNames []string
 		for _, fidx := range cfg.Fields {
-			fieldNames = append(fieldNames, cfg.FieldName(fidx))
+			fieldNames = append(fieldNames, cfg.FieldNames[fidx])
 		}
 
 		sqlw := &SQLite{

--- a/output/sqlite_test.go
+++ b/output/sqlite_test.go
@@ -45,17 +45,7 @@ func makeWriter(t *testing.T, raw bool, path string, truncate bool) baker.Output
 		return 0, false
 	}
 
-	fieldName := func(i baker.FieldIndex) string {
-		switch i {
-		case 0:
-			return "field0"
-		case 1:
-			return "field1"
-		case 2:
-			return "field2"
-		}
-		return ""
-	}
+	fieldNames := []string{"field0", "field1", "field2"}
 
 	params := baker.OutputParams{
 		Fields: []baker.FieldIndex{0, 1, 2},
@@ -63,7 +53,7 @@ func makeWriter(t *testing.T, raw bool, path string, truncate bool) baker.Output
 		ComponentParams: baker.ComponentParams{
 			DecodedConfig: cfg,
 			FieldByName:   fieldByName,
-			FieldName:     fieldName,
+			FieldNames:    fieldNames,
 		},
 	}
 	writer, err := newSQLiteWriter(raw)(params)
@@ -278,17 +268,7 @@ func TestSQLitePrePostCommands(t *testing.T) {
 		return 0, false
 	}
 
-	fieldName := func(i baker.FieldIndex) string {
-		switch i {
-		case 0:
-			return "field0"
-		case 1:
-			return "field1"
-		case 2:
-			return "field2"
-		}
-		return ""
-	}
+	fieldNames := []string{"field0", "field1", "field2"}
 
 	cfg := baker.OutputParams{
 		Fields: []baker.FieldIndex{0, 1, 2},
@@ -296,7 +276,7 @@ func TestSQLitePrePostCommands(t *testing.T) {
 		ComponentParams: baker.ComponentParams{
 			DecodedConfig: &config,
 			FieldByName:   fieldByName,
-			FieldName:     fieldName,
+			FieldNames:    fieldNames,
 		},
 	}
 	writer, err := newSQLiteWriter(false)(cfg)

--- a/output/stats.go
+++ b/output/stats.go
@@ -116,7 +116,7 @@ func (s *fieldStats) add(ll baker.Record) {
 	s.m[string(b)]++
 }
 
-func (s *fieldStats) print(w io.Writer, fieldName func(baker.FieldIndex) string) error {
+func (s *fieldStats) print(w io.Writer, fieldNames []string) error {
 	var smallest, biggest uint = math.MaxUint32, 0
 
 	qt := quantile.NewTargeted(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99)
@@ -135,7 +135,7 @@ func (s *fieldStats) print(w io.Writer, fieldName func(baker.FieldIndex) string)
 	csvw := csv.NewWriter(w)
 	if err := csvw.Write(
 		[]string{fmt.Sprintf(
-			"num samples (%s)", fieldName(s.field)),
+			"num samples (%s)", fieldNames[s.field]),
 			"smallest",
 			"1st %%ile", "5th %%ile", "10th %%ile", "25th %%ile", "50th %%ile", "75th %%ile", "90th %%ile", "95th %%ile", "99th %%ile",
 			"biggest"}); err != nil {
@@ -330,9 +330,9 @@ func (s *Stats) createStatsCSV() error {
 		(&s.times).print(buf)
 	}
 	for i := range s.fields {
-		fname := s.cfg.FieldName(s.fields[i].field)
+		fname := s.cfg.FieldNames[s.fields[i].field]
 		fmt.Fprintf(buf, "section,%s,distribution of number of log lines per distinct %s value\n", fname, fname)
-		s.fields[i].print(buf, s.cfg.FieldName)
+		s.fields[i].print(buf, s.cfg.FieldNames)
 	}
 	return ioutil.WriteFile(s.csvPath, buf.Bytes(), os.ModePerm)
 

--- a/stats.go
+++ b/stats.go
@@ -131,7 +131,7 @@ func (sd *StatsDumper) dumpNow() {
 		m := make(map[string]int64)
 		for f := range t.invalid {
 			if t.invalid[f] > 0 {
-				name := sd.t.fieldName(FieldIndex(f))
+				name := sd.t.fieldNames[f]
 				value := t.invalid[f]
 				m[name] = value
 				sd.metrics.RawCount("error_lines."+name, int64(value))

--- a/stats_test.go
+++ b/stats_test.go
@@ -139,15 +139,7 @@ fields=["field0"]
 			}
 			return 0, false
 		},
-		FieldName: func(f baker.FieldIndex) string {
-			switch f {
-			case 0:
-				return "field0"
-			case 1:
-				return "field1"
-			}
-			return ""
-		},
+		FieldNames: []string{"field0", "field1"},
 		Validate: func(r baker.Record) (bool, baker.FieldIndex) {
 			// field at index 0 must be "value0"
 			// field at index 1 must be "value1"

--- a/topology.go
+++ b/topology.go
@@ -43,8 +43,8 @@ type Topology struct {
 	wgout sync.WaitGroup
 	wgupl sync.WaitGroup
 
-	validate  ValidationFunc
-	fieldName func(FieldIndex) string // Used by StatsDumper
+	validate   ValidationFunc
+	fieldNames []string // Used by StatsDumper
 }
 
 // NewTopologyFromConfig gets a baker configuration and returns a Topology
@@ -55,7 +55,7 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 		filterProcs: cfg.FilterChain.Procs,
 		rawOutput:   cfg.Output.desc.Raw,
 		validate:    cfg.validate,
-		fieldName:   cfg.fieldName,
+		fieldNames:  cfg.fieldNames,
 		linePool: sync.Pool{
 			New: func() interface{} {
 				return cfg.createRecord()
@@ -82,7 +82,7 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 		ComponentParams{
 			DecodedConfig:  cfg.Input.DecodedConfig,
 			FieldByName:    cfg.fieldByName,
-			FieldName:      cfg.fieldName,
+			FieldNames:     cfg.fieldNames,
 			CreateRecord:   cfg.createRecord,
 			ValidateRecord: cfg.validate,
 			Metrics:        tp.metrics,
@@ -99,7 +99,7 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 			ComponentParams{
 				DecodedConfig:  cfg.Filter[idx].DecodedConfig,
 				FieldByName:    cfg.fieldByName,
-				FieldName:      cfg.fieldName,
+				FieldNames:     cfg.fieldNames,
 				CreateRecord:   cfg.createRecord,
 				ValidateRecord: cfg.validate,
 				Metrics:        tp.metrics,
@@ -130,7 +130,7 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 			ComponentParams: ComponentParams{
 				DecodedConfig:  cfg.Output.DecodedConfig,
 				FieldByName:    cfg.fieldByName,
-				FieldName:      cfg.fieldName,
+				FieldNames:     cfg.fieldNames,
 				CreateRecord:   cfg.createRecord,
 				ValidateRecord: cfg.validate,
 				Metrics:        tp.metrics,
@@ -182,7 +182,7 @@ func NewTopologyFromConfig(cfg *Config) (*Topology, error) {
 			ComponentParams{
 				DecodedConfig:  cfg.Upload.DecodedConfig,
 				FieldByName:    cfg.fieldByName,
-				FieldName:      cfg.fieldName,
+				FieldNames:     cfg.fieldNames,
 				CreateRecord:   cfg.createRecord,
 				ValidateRecord: cfg.validate,
 				Metrics:        tp.metrics,


### PR DESCRIPTION
#### :question: What

This replaces `FieldName func(baker.FieldIndex) string` with a simple slice called `FieldNames []string`

This is a tiny breaking change but it brings the following benefits:
 - code is simpler to read and write (see modified examples),
 - though not measured because it's not so important, but this is probably more performant
 - overall it gives the possibility to know the maximum number of defined fields, by just doing len(FieldNames), which was impossible to do before, and needed some times.
 - before, if the user provided an wrong index, the only way to return an error was to return an empty string, which has to be checked anyway. Now the user can avoid that by checking the index against the slice length, and if a wrong index is provided, go will panic with an out of bounds index message, which is way less dangerous that returning an empty string (and thus what could be considered as a valid field name)

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [ ] Has `make gofmt-write` been run on the code?
- [ ] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
