### PR TITLE
fix: building on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a bug in `logline.Copy` [#64](https://github.com/AdRoll/baker/pull/64)
+- Fix building on windows [#115](https://github.com/AdRoll/baker/issues/115)
 
 ### Maintenance
 

--- a/input/inpututils/fastreader.go
+++ b/input/inpututils/fastreader.go
@@ -1,82 +1,12 @@
+// +build !linux,!darwin
+
 package inpututils
 
 import (
-	"bytes"
-	"errors"
+	"compress/gzip"
 	"io"
-	"os/exec"
-	"strings"
-	"syscall"
 )
 
-// fastReader is an API-compatible drop-in replacement
-// for a compressed stream reader, That achieves a higher
-// decoding speed by spawning an external decompressing process
-// instance and pipeing data through it.
-// For example Go's native gzip implementation is about 2x slower at
-// decompressing data compared to zlib (mostly due to Go compiler
-// inefficiencies). So for tasks where the gzip decoding
-// speed is important, this is a quick workaround that doesn't
-// require cgo.
-// zcat is part of the gzip package and comes preinstalled on
-// most Linux distributions and on OSX.
-// zstdcat can easily be installed on osx and linux
-type fastReader struct {
-	io.ReadCloser
-	command []string
-	stderr  bytes.Buffer
-	close   func() error
-}
-
-func newFastGzReader(r io.Reader) (*fastReader, error) {
-	return newFastReader([]string{"zcat"}, r)
-}
-
-func newFastReader(command []string, r io.Reader) (*fastReader, error) {
-	fr := fastReader{command: command}
-	if err := fr.Reset(r); err != nil {
-		return nil, err
-	}
-	return &fr, nil
-}
-
-func (fr *fastReader) Reset(r io.Reader) error {
-	if fr.close != nil {
-		fr.close()
-	}
-
-	cmd := exec.Command(fr.command[0], fr.command[1:]...)
-	cmd.Stdin = r
-	cmd.Stderr = &fr.stderr
-
-	rpipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	// Don't get the process killed at CTRL+C
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid: true,
-	}
-	err = cmd.Start()
-	if err != nil {
-		rpipe.Close()
-		return err
-	}
-
-	fr.ReadCloser = rpipe
-	fr.close = func() error {
-		rpipe.Close()
-		if err := cmd.Wait(); err != nil {
-			if _, ok := err.(*exec.ExitError); ok {
-				return errors.New(strings.TrimSpace(fr.stderr.String()))
-			}
-		}
-		return err
-	}
-	return nil
-}
-
-func (fr *fastReader) Close() error {
-	return fr.close()
+func newFastGzReader(r io.Reader) (*gzip.Reader, error) {
+	return gzip.NewReader(r)
 }

--- a/input/inpututils/fastreader_unix.go
+++ b/input/inpututils/fastreader_unix.go
@@ -1,0 +1,84 @@
+// +build linux darwin
+
+package inpututils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// fastReader is an API-compatible drop-in replacement
+// for a compressed stream reader, That achieves a higher
+// decoding speed by spawning an external decompressing process
+// instance and pipeing data through it.
+// For example Go's native gzip implementation is about 2x slower at
+// decompressing data compared to zlib (mostly due to Go compiler
+// inefficiencies). So for tasks where the gzip decoding
+// speed is important, this is a quick workaround that doesn't
+// require cgo.
+// zcat is part of the gzip package and comes preinstalled on
+// most Linux distributions and on OSX.
+// zstdcat can easily be installed on osx and linux
+type fastReader struct {
+	io.ReadCloser
+	command []string
+	stderr  bytes.Buffer
+	close   func() error
+}
+
+func newFastGzReader(r io.Reader) (*fastReader, error) {
+	return newFastReader([]string{"zcat"}, r)
+}
+
+func newFastReader(command []string, r io.Reader) (*fastReader, error) {
+	fr := fastReader{command: command}
+	if err := fr.Reset(r); err != nil {
+		return nil, err
+	}
+	return &fr, nil
+}
+
+func (fr *fastReader) Reset(r io.Reader) error {
+	if fr.close != nil {
+		fr.close()
+	}
+
+	cmd := exec.Command(fr.command[0], fr.command[1:]...)
+	cmd.Stdin = r
+	cmd.Stderr = &fr.stderr
+
+	rpipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	// Don't get the process killed at CTRL+C
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+	err = cmd.Start()
+	if err != nil {
+		rpipe.Close()
+		return err
+	}
+
+	fr.ReadCloser = rpipe
+	fr.close = func() error {
+		rpipe.Close()
+		if err := cmd.Wait(); err != nil {
+			if _, ok := err.(*exec.ExitError); ok {
+				return errors.New(strings.TrimSpace(fr.stderr.String()))
+			}
+		}
+		return err
+	}
+	return nil
+}
+
+func (fr *fastReader) Close() error {
+	return fr.close()
+}


### PR DESCRIPTION
#### :question: What

Fix the building issues on Windows (#115).  
Now, the `FastGzReader` uses the [gzip reader](https://pkg.go.dev/compress/gzip#NewReader) of the go std by default. The previous optimization will be available only on Linux and Mac.

#### :white_check_mark: Checklists

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
