### PR TITLE
fix: path issue on tests on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a bug in `logline.Copy` [#64](https://github.com/AdRoll/baker/pull/64)
-- Fix `list_test` with file URI to be compatible with windows paths
+- Fix `list_test` with file URI to be compatible with windows paths [#117](https://github.com/AdRoll/baker/pull/117)
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix a bug in `logline.Copy` [#64](https://github.com/AdRoll/baker/pull/64)
+- Fix `list_test` with file URI to be compatible with windows paths
 
 ### Maintenance
 


### PR DESCRIPTION
#### :question: What

Fix `list_test` on windows. We use [file URI](https://en.wikipedia.org/wiki/File_URI_scheme) instead of Unix path, which permits us to be cross-platform and compatible with windows paths. 

#### :white_check_mark: Checklists

- [x] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
