### PR TITLE
fix: assignFieldMapping test skip a case

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -179,10 +179,7 @@ func Test_assignFieldMapping(t *testing.T) {
 					Names: []string{"foo", "bar", "baz", "baz"},
 				},
 			},
-			comp: Components{
-				FieldByName: fieldByName,
-				FieldNames:  fieldNames,
-			},
+			comp:    Components{},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
#### :question: What

The test case `duplicated field name`  of `Test_assignFieldMapping` does not correctly check the intended case because a Components is passed. The function will be stopped with the error `field indexes/names can't both be set in TOML and Components` and not `duplicated field name "baz"`.

Here the coverage screenshot:

![Screenshot from 2021-02-03 10-21-44](https://user-images.githubusercontent.com/6934358/106726816-19e45580-660b-11eb-81e8-8dac04935a7d.png)

#### :white_check_mark: Checklists

- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
