### PR TITLE
fix: change docker image with hugo official one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:alpine3.10
+FROM klakegg/hugo:ext-alpine
 
-RUN apk add hugo git
 RUN npm install -g postcss-cli autoprefixer postcss
+
 EXPOSE 1313

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-base:
 	docker build -t baker-docs:base .
 
 docker-dev: docker-base ## Use docker for baker website development
-	docker run -w /baker -v $$PWD:/baker -p 1313:1313 -it baker-docs:base hugo server --bind=0.0.0.0
+	docker run -w /baker -v $$PWD:/baker -p 1313:1313 -it baker-docs:base server --bind=0.0.0.0
 
 .PHONY: build docker-base
 


### PR DESCRIPTION
#### :question: What

The alpine repository has an old version of HUGO, which do not correctly compile the web site.
This PR changes the Docker image with the HUGO official one.

#### :white_check_mark: Checklists

- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
