### PR TITLE
feat: add IncDedup filter

### DIFF
--- a/filter/all.go
+++ b/filter/all.go
@@ -10,6 +10,7 @@ var All = []baker.FilterDesc{
 	ClauseFilterDesc,
 	ClearFieldsDesc,
 	ConcatenateDesc,
+	IncDedupDesc,
 	NotNullDesc,
 	PartialCloneDesc,
 	RegexMatchDesc,

--- a/filter/inc_dedup.go
+++ b/filter/inc_dedup.go
@@ -1,0 +1,81 @@
+package filter
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/AdRoll/baker"
+)
+
+// shared set of type: map[string]struct{}
+var incDedupSet sync.Map
+
+var IncDedupDesc = baker.FilterDesc{
+	Name:   "IncDedup",
+	New:    NewIncDedup,
+	Config: &IncDedupConfig{},
+	Help:   "Removes identical records",
+}
+
+type IncDedupConfig struct {
+	Fields []string `help:"fields that needs to be unique" required:"true"`
+}
+
+type IncDedup struct {
+	cfg *IncDedupConfig
+
+	fields []baker.FieldIndex
+
+	numProcessedLines int64
+	numFilteredLines  int64
+}
+
+func NewIncDedup(cfg baker.FilterParams) (baker.Filter, error) {
+	if cfg.DecodedConfig == nil {
+		cfg.DecodedConfig = &IncDedupConfig{}
+	}
+	dcfg := cfg.DecodedConfig.(*IncDedupConfig)
+
+	f := &IncDedup{
+		cfg: dcfg,
+	}
+	for _, field := range dcfg.Fields {
+		i, ok := cfg.FieldByName(field)
+		if !ok {
+			return nil, fmt.Errorf("unrecognized deduplication field %q", field)
+		}
+		f.fields = append(f.fields, i)
+	}
+	return f, nil
+}
+
+func (f *IncDedup) Stats() baker.FilterStats {
+	return baker.FilterStats{
+		NumProcessedLines: atomic.LoadInt64(&f.numProcessedLines),
+		NumFilteredLines:  atomic.LoadInt64(&f.numFilteredLines),
+	}
+}
+
+func (f *IncDedup) Process(l baker.Record, next func(baker.Record)) {
+	atomic.AddInt64(&f.numProcessedLines, 1)
+
+	key := f.constructKey(l)
+	_, found := incDedupSet.LoadOrStore(key, struct{}{})
+
+	if found {
+		atomic.AddInt64(&f.numFilteredLines, 1)
+	} else {
+		next(l)
+	}
+}
+
+// constructKey build a key with the concatenation of all the fields
+func (f *IncDedup) constructKey(l baker.Record) string {
+	var sb strings.Builder
+	for _, i := range f.fields {
+		sb.Write(l.Get(i))
+	}
+	return sb.String()
+}

--- a/filter/inc_dedup_test.go
+++ b/filter/inc_dedup_test.go
@@ -1,0 +1,128 @@
+package filter
+
+import (
+	"testing"
+
+	"github.com/AdRoll/baker"
+)
+
+func TestIncDedup(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []string
+		fields  []string
+		want    int // number of output records
+		wantErr bool
+	}{
+		{
+			name: "all different",
+			records: []string{
+				"abc1,def1,ghi1",
+				"abc2,def2,ghi2",
+				"abc3,def3,ghi3",
+			},
+			fields: []string{"f1", "f2", "f3"},
+			want:   3,
+		},
+		{
+			name: "all equal",
+			records: []string{
+				"abc,def,ghi",
+				"abc,def,ghi",
+				"abc,def,ghi",
+			},
+			fields: []string{"f1", "f2", "f3"},
+			want:   1,
+		},
+		{
+			name: "1 field equal",
+			records: []string{
+				"abc,def1,ghi1",
+				"abc,def2,ghi2",
+				"abc,def3,ghi3",
+			},
+			fields: []string{"f1"},
+			want:   1,
+		},
+		{
+			name: "1 field different",
+			records: []string{
+				"abc,def1,ghi",
+				"abc,def2,ghi",
+				"abc,def3,ghi",
+			},
+			fields: []string{"f2"},
+			want:   3,
+		},
+
+		// errors
+		{
+			name: "not existing field",
+			records: []string{
+				"abc,def,ghi",
+			},
+			fields:  []string{"not_exist"},
+			wantErr: true,
+		},
+	}
+
+	fieldByName := func(name string) (baker.FieldIndex, bool) {
+		switch name {
+		case "f1":
+			return 0, true
+		case "f2":
+			return 1, true
+		case "f3":
+			return 2, true
+		}
+		return 0, false
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// clear the shared set
+			incDedupSet.Range(func(key, _ interface{}) bool {
+				incDedupSet.Delete(key)
+				return true
+			})
+
+			// create two filter to simulate concurrent running instances
+			params := baker.FilterParams{
+				ComponentParams: baker.ComponentParams{
+					FieldByName: fieldByName,
+					DecodedConfig: &IncDedupConfig{
+						Fields: tt.fields,
+					},
+				},
+			}
+			f1, err := NewIncDedup(params)
+			if (err != nil) != (tt.wantErr) {
+				t.Fatalf("got error = %v, want error = %v", err, tt.wantErr)
+			}
+			f2, _ := NewIncDedup(params)
+
+			if tt.wantErr {
+				return
+			}
+
+			var count int
+			next := func(baker.Record) { count++ }
+
+			for i, rec := range tt.records {
+				l := &baker.LogLine{FieldSeparator: ','}
+				if err := l.Parse([]byte(rec), nil); err != nil {
+					t.Fatalf("parse error: %q", err)
+				}
+				if i%2 == 0 {
+					f1.Process(l, next)
+				} else {
+					f2.Process(l, next)
+				}
+			}
+
+			if count != tt.want {
+				t.Errorf("got %d record, want %d", count, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### :question: What

Add the `IncDedup` filter. `IncDedup` filter out records with contains identical values on configurable fields.

Possible configuration of the filter is:
```
[[filter]]
name="IncDedup"
	[filter.config]
	Fields=["target"]
```
In this example the following records will be filtered out as follows:

__Input:__

| name | targert |
|:-------:|:---------:|
| foo    | bar       |
| foo    | foo       |
| baz   | bar       |

__Output:__

| name | targert |
|:-------:|:---------:|
| foo    | bar       |
| foo    | foo       |

#### :hammer: How to test

1. Configure the filter in the TOML
3. Run Baker with an appropriate input

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
