### PR TITLE
feat: add Hash filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PartialClone filter [#107](https://github.com/AdRoll/baker/pull/107)
 - Add `[validation]` section in TOML in which users can define record validation through regex [#122](https://github.com/AdRoll/baker/pull/122)
 - Add ExpandJSON filter [#128](https://github.com/AdRoll/baker/pull/128)
+- Add Hash filter with the support of md5 and sha256 algorithms [#130](https://github.com/AdRoll/baker/pull/130)
 
 ### Changed
 

--- a/filter/all.go
+++ b/filter/all.go
@@ -10,6 +10,7 @@ var All = []baker.FilterDesc{
 	ClauseFilterDesc,
 	ClearFieldsDesc,
 	ConcatenateDesc,
+	HashDesc,
 	MetadataLastModifiedDesc,
 	NotNullDesc,
 	PartialCloneDesc,

--- a/filter/hash.go
+++ b/filter/hash.go
@@ -1,0 +1,132 @@
+package filter
+
+import (
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/AdRoll/baker"
+	log "github.com/sirupsen/logrus"
+)
+
+// HashDesc describes the Hash filter
+var HashDesc = baker.FilterDesc{
+	Name:   "Hash",
+	New:    NewHash,
+	Config: &HashConfig{},
+	Help: `This filter hashes a field using a specified hash function and writes the value 
+to another (or the same) field. In order to have control over the set of characters
+present, the hashed value can optionally be encoded.
+	
+	
+Supported hash functions:
+ - md5
+ - sha256
+
+Supported encodings:
+- hex (hexadecimal encoding)
+`,
+}
+
+type HashConfig struct {
+	SrcField string `help:"Name of the field to hash" required:"true"`
+	DstField string `help:"Name of the field to write the result to" required:"true"`
+	Function string `help:"Name of the hash function to use" required:"true"`
+	Encoding string `help:"Name of the encoding function to use" required:"false"`
+}
+
+type Hash struct {
+	numProcessedLines int64
+	numFilteredLines  int64
+
+	src    baker.FieldIndex
+	dst    baker.FieldIndex
+	hash   func([]byte) ([]byte, error)
+	encode func([]byte) ([]byte, error)
+}
+
+func NewHash(cfg baker.FilterParams) (baker.Filter, error) {
+	if cfg.DecodedConfig == nil {
+		cfg.DecodedConfig = &HashConfig{}
+	}
+	dcfg := cfg.DecodedConfig.(*HashConfig)
+
+	src, ok := cfg.FieldByName(dcfg.SrcField)
+	if !ok {
+		return nil, fmt.Errorf("can't find the SrcField %s", dcfg.SrcField)
+	}
+
+	dst, ok := cfg.FieldByName(dcfg.DstField)
+	if !ok {
+		return nil, fmt.Errorf("can't find the DstField %s", dcfg.DstField)
+	}
+
+	h := &Hash{
+		src: src,
+		dst: dst,
+	}
+
+	switch dcfg.Function {
+	case "md5":
+		hf := md5.New()
+		h.hash = func(b []byte) ([]byte, error) {
+			hf.Reset()
+			hf.Write(b)
+			return hf.Sum(nil), nil
+		}
+	case "sha256":
+		hf := sha256.New()
+		h.hash = func(b []byte) ([]byte, error) {
+			hf.Reset()
+			hf.Write(b)
+			return hf.Sum(nil), nil
+		}
+	default:
+		return nil, fmt.Errorf("unsupported hash function %s", dcfg.Function)
+	}
+
+	switch dcfg.Encoding {
+	case "hex":
+		h.encode = func(b []byte) ([]byte, error) {
+			dst := make([]byte, hex.EncodedLen(len(b)))
+			hex.Encode(dst, b)
+			return dst, nil
+		}
+	case "": // pass through
+		h.encode = func(b []byte) ([]byte, error) { return b, nil }
+	default:
+		return nil, fmt.Errorf("unsupported encoding %s", dcfg.Encoding)
+	}
+
+	return h, nil
+}
+
+func (h *Hash) Stats() baker.FilterStats {
+	return baker.FilterStats{
+		NumProcessedLines: atomic.LoadInt64(&h.numProcessedLines),
+		NumFilteredLines:  atomic.LoadInt64(&h.numFilteredLines),
+	}
+}
+
+func (h *Hash) Process(r baker.Record, next func(baker.Record)) {
+	atomic.AddInt64(&h.numProcessedLines, 1)
+
+	hashed, err := h.hash(r.Get(h.src))
+	if err != nil {
+		log.Errorf("can't process record, hashing failed: %v", err)
+		atomic.AddInt64(&h.numFilteredLines, 1)
+		return
+	}
+
+	encoded, err := h.encode(hashed)
+	if err != nil {
+		log.Errorf("can't process record, encoding failed: %v", err)
+		atomic.AddInt64(&h.numFilteredLines, 1)
+		return
+	}
+
+	r.Set(h.dst, encoded)
+	next(r)
+}

--- a/filter/hash.go
+++ b/filter/hash.go
@@ -70,18 +70,14 @@ func NewHash(cfg baker.FilterParams) (baker.Filter, error) {
 
 	switch dcfg.Function {
 	case "md5":
-		hf := md5.New()
 		h.hash = func(b []byte) ([]byte, error) {
-			hf.Reset()
-			hf.Write(b)
-			return hf.Sum(nil), nil
+			sum := md5.Sum(b)
+			return sum[:], nil
 		}
 	case "sha256":
-		hf := sha256.New()
 		h.hash = func(b []byte) ([]byte, error) {
-			hf.Reset()
-			hf.Write(b)
-			return hf.Sum(nil), nil
+			sum := sha256.Sum256(b)
+			return sum[:], nil
 		}
 	default:
 		return nil, fmt.Errorf("unsupported hash function %s", dcfg.Function)

--- a/filter/hash_test.go
+++ b/filter/hash_test.go
@@ -1,0 +1,144 @@
+package filter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/AdRoll/baker"
+)
+
+func TestHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		record  string
+		src     string
+		dst     string
+		hash    string
+		encode  string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:   "md5",
+			record: "abc,def,ghi",
+			src:    "f1",
+			dst:    "f3",
+			hash:   "md5",
+			encode: "",
+			want:   []byte{144, 1, 80, 152, 60, 210, 79, 176, 214, 150, 63, 125, 40, 225, 127, 114},
+		},
+		{
+			name:   "md5 + hex",
+			record: "abc,def,ghi",
+			src:    "f1",
+			dst:    "f3",
+			hash:   "md5",
+			encode: "hex",
+			want:   []byte{57, 48, 48, 49, 53, 48, 57, 56, 51, 99, 100, 50, 52, 102, 98, 48, 100, 54, 57, 54, 51, 102, 55, 100, 50, 56, 101, 49, 55, 102, 55, 50},
+		},
+		{
+			name:   "sha256",
+			record: "abc,def,ghi",
+			src:    "f1",
+			dst:    "f3",
+			hash:   "sha256",
+			encode: "",
+			want:   []byte{186, 120, 22, 191, 143, 1, 207, 234, 65, 65, 64, 222, 93, 174, 34, 35, 176, 3, 97, 163, 150, 23, 122, 156, 180, 16, 255, 97, 242, 0, 21, 173},
+		},
+		{
+			name:   "sha256 + hex",
+			record: "abc,def,ghi",
+			src:    "f1",
+			dst:    "f3",
+			hash:   "sha256",
+			encode: "hex",
+			want:   []byte{98, 97, 55, 56, 49, 54, 98, 102, 56, 102, 48, 49, 99, 102, 101, 97, 52, 49, 52, 49, 52, 48, 100, 101, 53, 100, 97, 101, 50, 50, 50, 51, 98, 48, 48, 51, 54, 49, 97, 51, 57, 54, 49, 55, 55, 97, 57, 99, 98, 52, 49, 48, 102, 102, 54, 49, 102, 50, 48, 48, 49, 53, 97, 100},
+		},
+
+		// errors
+		{
+			name:    "Function error",
+			src:     "f1",
+			dst:     "f3",
+			hash:    "hash-not-exist",
+			encode:  "hex",
+			wantErr: true,
+		},
+		{
+			name:    "Encoding error",
+			src:     "f1",
+			dst:     "f3",
+			hash:    "md5",
+			encode:  "encoding-not-exist",
+			wantErr: true,
+		},
+		{
+			name:    "SrcField error",
+			src:     "not-exist",
+			dst:     "f1",
+			hash:    "md5",
+			encode:  "hex",
+			wantErr: true,
+		},
+		{
+			name:    "DstField error",
+			src:     "f1",
+			dst:     "not-exist",
+			hash:    "md5",
+			encode:  "hex",
+			wantErr: true,
+		},
+	}
+
+	fieldByName := func(name string) (baker.FieldIndex, bool) {
+		switch name {
+		case "f1":
+			return 0, true
+		case "f2":
+			return 1, true
+		case "f3":
+			return 2, true
+		}
+		return 0, false
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewHash(baker.FilterParams{
+				ComponentParams: baker.ComponentParams{
+					FieldByName: fieldByName,
+					DecodedConfig: &HashConfig{
+						Function: tt.hash,
+						Encoding: tt.encode,
+						SrcField: tt.src,
+						DstField: tt.dst,
+					},
+				},
+			})
+
+			if (err != nil) != (tt.wantErr) {
+				t.Fatalf("got error = %v, want error = %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			rec1 := &baker.LogLine{FieldSeparator: ','}
+			if err := rec1.Parse([]byte(tt.record), nil); err != nil {
+				t.Fatalf("parse error: %q", err)
+			}
+
+			f.Process(rec1, func(rec2 baker.Record) {
+				id, ok := fieldByName(tt.dst)
+				if !ok {
+					t.Fatalf("cannot find field name")
+				}
+				hash := rec2.Get(id)
+				if !bytes.Equal(hash, tt.want) {
+					t.Errorf("got hash %q, want %q", hash, tt.want)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
#### :question: What

The `Hash` filter hashes a field using a specified hash function and writes the value on another (or the same) field.
Hash function supported:
- md5
- sha256

It is also possible to encode the hash with _hexadecimal encoding_ to avoids encoding problems.

#### :hammer: How to test

1. Add the `Hash` filter into a Baker TOML
2. Properly configure it
3. Run Baker

#### :white_check_mark: Checklists

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
