### PR TITLE
fix: cover all MetadataLastModified test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PartialClone filter [#107](https://github.com/AdRoll/baker/pull/107)
 - Add `[validation]` section in TOML in which users can define record validation through regex [#122](https://github.com/AdRoll/baker/pull/122)
 - Add ExpandJSON filter [#128](https://github.com/AdRoll/baker/pull/128)
+- Add MetadataLastModified filter [#133](https://github.com/AdRoll/baker/pull/133)
 
 ### Changed
 

--- a/filter/metadata_lastmodified.go
+++ b/filter/metadata_lastmodified.go
@@ -14,12 +14,11 @@ var MetadataLastModifiedDesc = baker.FilterDesc{
 	Name:   "MetadataLastModified",
 	New:    NewMetadataLastModified,
 	Config: &MetadataLastModifiedConfig{},
-	Help: `Set the last modified timestamp of the underlaying data source of the log line
-into a connfigurable Field.`,
+	Help:   `Extract the "last modified" timestamp from the record Metadata and write it to the selected field.`,
 }
 
 type MetadataLastModifiedConfig struct {
-	DstField string `help:"Name of the field into which write the timestamp" required:"true"`
+	DstField string `help:"Name of the field into which write the timestamp to" required:"true"`
 }
 
 type MetadataLastModified struct {

--- a/filter/metadata_lastmodified_test.go
+++ b/filter/metadata_lastmodified_test.go
@@ -22,12 +22,12 @@ func TestMetadataLastModified(t *testing.T) {
 	}{
 		{
 			name:         "time set",
-			lastmodified: ptr(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
+			lastmodified: ptr(time.Unix(1257894000, 0)),
 			dst:          "f2",
 			want:         "1257894000",
 		},
 		{
-			name:         "time set at zero",
+			name:         "time zero-value",
 			lastmodified: &time.Time{},
 			dst:          "f2",
 			want:         "",

--- a/filter/metadata_lastmodified_test.go
+++ b/filter/metadata_lastmodified_test.go
@@ -9,22 +9,32 @@ import (
 )
 
 func TestMetadataLastModified(t *testing.T) {
+	ptr := func(t time.Time) *time.Time {
+		return &t
+	}
+
 	tests := []struct {
 		name         string
-		lastmodified time.Time
+		lastmodified *time.Time
 		dst          string
 		want         string
 		wantErr      bool
 	}{
 		{
 			name:         "time set",
-			lastmodified: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+			lastmodified: ptr(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
 			dst:          "f2",
 			want:         "1257894000",
 		},
 		{
-			name:         "time empty",
-			lastmodified: time.Time{},
+			name:         "time set at zero",
+			lastmodified: &time.Time{},
+			dst:          "f2",
+			want:         "",
+		},
+		{
+			name:         "time not set",
+			lastmodified: nil,
 			dst:          "f2",
 			want:         "",
 		},
@@ -70,8 +80,8 @@ func TestMetadataLastModified(t *testing.T) {
 
 			rec1 := &baker.LogLine{FieldSeparator: ','}
 			var bakerMetadata baker.Metadata
-			if !tt.lastmodified.IsZero() {
-				bakerMetadata = baker.Metadata{inpututils.MetadataLastModified: tt.lastmodified}
+			if tt.lastmodified != nil {
+				bakerMetadata = baker.Metadata{inpututils.MetadataLastModified: *tt.lastmodified}
 			}
 			if err := rec1.Parse([]byte{}, bakerMetadata); err != nil {
 				t.Fatalf("parse error: %q", err)


### PR DESCRIPTION
#### :question: What

This is an update of PR #131. It adds the test case in which the date is set but it is zero.

#### :white_check_mark: Checklists

- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
