### PR TITLE
fix: add ExpandJSON to all.go

### DIFF
--- a/filter/all.go
+++ b/filter/all.go
@@ -10,6 +10,7 @@ var All = []baker.FilterDesc{
 	ClauseFilterDesc,
 	ClearFieldsDesc,
 	ConcatenateDesc,
+	ExpandJSONDesc,
 	MetadataLastModifiedDesc,
 	NotNullDesc,
 	PartialCloneDesc,


### PR DESCRIPTION
#### :question: What

The ExpandJSON filter was not added to the all.go file

#### :white_check_mark: Checklists

- [x] Have new components been added to the related `all.go` files?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
