### PR TITLE
fix: PrintHelp wrongly insert newlines after dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix some bugs in `s3.s3UploadFile` [#120](https://github.com/AdRoll/baker/pull/120)
 - `SplitWriter` leaves some file descriptors open [#119](https://github.com/AdRoll/baker/pull/119) and [#121](https://github.com/AdRoll/baker/pull/121)
 - `List` input did not consider drive letter on Windows paths [#139](https://github.com/AdRoll/baker/pull/139)
-- `PrintHelp()` wrongly insert newline after dots [#140](https://github.com/AdRoll/baker/pull/140)
+- Stop to insert newline after dots in generated help markdown [#140](https://github.com/AdRoll/baker/pull/140)
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SplitWriter` leaves some file descriptors open [#119](https://github.com/AdRoll/baker/pull/119) and [#121](https://github.com/AdRoll/baker/pull/121)
 - `PrintHelper()` now supports map type as configuration parameter of a Baker component [#138](https://github.com/AdRoll/baker/pull/138)
 - `List` input did not consider drive letter on Windows paths [#139](https://github.com/AdRoll/baker/pull/139)
-- Stop to insert newline after dots in generated help markdown [#140](https://github.com/AdRoll/baker/pull/140)
+- Do not insert newline after dots in generated help markdown [#140](https://github.com/AdRoll/baker/pull/140)
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix some bugs in `s3.s3UploadFile` [#120](https://github.com/AdRoll/baker/pull/120)
 - `SplitWriter` leaves some file descriptors open [#119](https://github.com/AdRoll/baker/pull/119) and [#121](https://github.com/AdRoll/baker/pull/121)
 - `List` input did not consider drive letter on Windows paths [#139](https://github.com/AdRoll/baker/pull/139)
+- `PrintHelp()` wrongly insert newline after dots [#140](https://github.com/AdRoll/baker/pull/140)
 
 ### Maintenance
 

--- a/help_markdown.go
+++ b/help_markdown.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"strings"
 
 	"github.com/charmbracelet/glamour"
 )
@@ -79,20 +78,11 @@ func GenerateMarkdownHelp(w io.Writer, desc interface{}) error {
 	return nil
 }
 
-func breakAfterDots(s string) string {
-	r := strings.NewReplacer(
-		".", ".  \n",
-		"!", "!  \n",
-		"?", "?  \n",
-	)
-	return r.Replace(s)
-}
-
 func genInputMarkdown(w io.Writer, doc inputDoc) {
 	fmt.Fprintf(w, "## Input *%s*\n", doc.name)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Overview")
-	fmt.Fprintln(w, breakAfterDots(doc.help))
+	fmt.Fprintln(w, doc.help)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Configuration")
 	if len(doc.keys) == 0 {
@@ -107,7 +97,7 @@ func genFilterMarkdown(w io.Writer, doc filterDoc) {
 	fmt.Fprintf(w, "## Filter *%s*\n", doc.name)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Overview")
-	fmt.Fprintln(w, breakAfterDots(doc.help))
+	fmt.Fprintln(w, doc.help)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Configuration")
 	if len(doc.keys) == 0 {
@@ -134,7 +124,7 @@ func genOutputMarkdown(w io.Writer, doc outputDoc) {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w)
-	fmt.Fprintln(w, breakAfterDots(doc.help))
+	fmt.Fprintln(w, doc.help)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Configuration")
 	if len(doc.keys) == 0 {
@@ -149,7 +139,7 @@ func genUploadMarkdown(w io.Writer, doc uploadDoc) {
 	fmt.Fprintf(w, "## Upload *%s*\n", doc.name)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Overview")
-	fmt.Fprintln(w, breakAfterDots(doc.help))
+	fmt.Fprintln(w, doc.help)
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "### Configuration")
 	if len(doc.keys) == 0 {


### PR DESCRIPTION
#### :question: What

The Glamour library already manages the newlines properly.

#### :white_check_mark: Checklists

- [x] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
