### PR TITLE
fix: occasional race on stats_test

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -2,7 +2,6 @@ package baker_test
 
 import (
 	"bytes"
-	"flag"
 	"io/ioutil"
 	"math"
 	"os"
@@ -103,7 +102,6 @@ func TestStatsDumper(t *testing.T) {
 	time.Sleep(1050 * time.Millisecond)
 	stop()
 
-	flag.Parse()
 	golden := filepath.Join("testdata", t.Name()+".golden")
 	if *testutil.UpdateGolden {
 		ioutil.WriteFile(golden, buf.Bytes(), os.ModePerm)


### PR DESCRIPTION
#### :question: What

Remove `flag.Parse()` call inside the `TestStatsDumper` to avoid an occasional race condition.
The flags are automatically parsed by the testing library, [ref1](https://github.com/golang/go/issues/38952), [ref2](https://pkg.go.dev/testing#hdr-Main).

#### :white_check_mark: Checklists

- [x] Have the changes in this PR been functionally tested?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
