### PR TITLE
doc: update KeySeparator default value in Dedup

### DIFF
--- a/filter/dedup.go
+++ b/filter/dedup.go
@@ -29,7 +29,7 @@ var DedupDesc = baker.FilterDesc{
 
 type DedupConfig struct {
 	Fields       []string `help:"fields to consider when comparing records" required:"true"`
-	KeySeparator string   `help:"character separator used to build a key from the fields" default:"\x1e"`
+	KeySeparator string   `help:"character separator used to build a key from the fields" default:"\\x1e"`
 }
 
 func (cfg *DedupConfig) fillDefaults() {


### PR DESCRIPTION
#### :question: What

Not printable `\x1e` character was not shown in the Dedup filter documentation.

#### :white_check_mark: Checklists

- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
