### PR TITLE
Remove flaky test from TCP input

### DIFF
--- a/input/tcp.go
+++ b/input/tcp.go
@@ -99,8 +99,11 @@ func (s *TCP) Run(inch chan<- *baker.Data) error {
 		ctxLog.WithFields(log.Fields{"addr": conn.RemoteAddr()}).Info("Connected")
 		wg.Add(1)
 		go func(conn *net.TCPConn) {
-			defer wg.Done()
-			s.handleStream(conn)
+			defer func() {
+				conn.Close()
+				wg.Done()
+			}()
+
 			err := s.handleStream(conn)
 			if err != nil {
 				ctxLog.WithError(err).WithFields(log.Fields{"error": err}).Error("Error when handling stream")
@@ -137,8 +140,6 @@ func (s *TCP) Stats() baker.InputStats {
 func (s *TCP) Stop() {
 	atomic.StoreInt64(&s.stop, 1)
 }
-
-	defer conn.Close()
 
 func (s *TCP) handleStream(conn *net.TCPConn) error {
 	// r, err := newFastGzReader(conn)

--- a/input/tcp.go
+++ b/input/tcp.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -90,7 +92,7 @@ func (s *TCP) Run(inch chan<- *baker.Data) error {
 		l.SetDeadline(time.Now().Add(1 * time.Second))
 		conn, err := l.AcceptTCP()
 		if err != nil {
-			if opErr, ok := err.(*net.OpError); ok && opErr.Timeout() {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
 				continue
 			}
 			ctxLog.WithFields(log.Fields{"error": err}).Error("Error while accepting")

--- a/input/tcp.go
+++ b/input/tcp.go
@@ -142,12 +142,11 @@ func (s *TCP) Stop() {
 }
 
 func (s *TCP) handleStream(conn *net.TCPConn) error {
-	// r, err := newFastGzReader(conn)
 	r, err := gzip.NewReader(conn)
 	if err != nil {
 		return fmt.Errorf("error initializing gzip: %v", err)
 	}
-	// defer r.Close()
+	defer r.Close()
 
 	rbuf := bufio.NewReaderSize(r, tcpChunkBuffer)
 

--- a/input/tcp_test.go
+++ b/input/tcp_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/AdRoll/baker/output/outputtest"
 )
 
-// this test checks that, given a reasonable amount of time (500ms) and under
+// This test checks that, given a reasonable amount of time (500ms) and under
 // normal conditions, all log lines sent one by one on the TCP socket are
 // received by the output.
 func TestTCP1by1(t *testing.T) {
@@ -95,7 +95,7 @@ func TestTCP1by1(t *testing.T) {
 	}
 }
 
-// this test checks that, given a reasonable amount of time (500ms) and under
+// This test checks that, given a reasonable amount of time (500ms) and under
 // normal conditions, all log lines sent by chunk on the TCP socket are
 // received by the output.
 func TestTCPChunks(t *testing.T) {
@@ -184,97 +184,5 @@ func TestTCPChunks(t *testing.T) {
 	want := nchunks * chunksize
 	if len(out.Records) != want {
 		t.Errorf("want %d log lines, got %d", want, len(out.Records))
-	}
-}
-
-// this test checks that when the topology is stopped while some log lines
-// are sent in chunks via TCP, the number of log lines safely recevied by
-// the output is a multiple of the chunk size (i.e whole chunks are received
-// correctly).
-func TestTCPStopChunk(t *testing.T) {
-	toml := `
-	[fields]
-	names = ["f0", "f1", "f2"]
-
-	[input]
-	name="TCP"
-
-	[output]
-	name="RawRecorder"
-	procs=1
-	`
-	c := baker.Components{
-		Inputs:  []baker.InputDesc{TCPDesc},
-		Outputs: []baker.OutputDesc{outputtest.RawRecorderDesc},
-	}
-
-	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml), c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	topology, err := baker.NewTopologyFromConfig(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	topology.Start()
-	// Give baker some time to start the tcp server
-	time.Sleep(500 * time.Millisecond)
-
-	const chunksz = 29 // number of log lines in a chunk
-
-	errc := make(chan error, 1)
-	go func() {
-		conn, err := net.Dial("tcp", ":6000")
-		if err != nil {
-			errc <- err
-			return
-		}
-		defer conn.Close()
-
-		w := gzip.NewWriter(conn)
-		defer w.Close()
-		buf := &bytes.Buffer{}
-
-		// Aynchronously stop topology after 250ms
-		time.AfterFunc(250*time.Millisecond, func() {
-			topology.Stop()
-		})
-		for {
-			buf.Reset()
-			for i := 0; i < chunksz; i++ {
-				l := baker.LogLine{FieldSeparator: baker.DefaultLogLineFieldSeparator}
-				l.Set(1, []byte("field"))
-				buf.Write(l.ToText(nil))
-				buf.WriteByte('\n')
-				if _, err := buf.WriteTo(w); err != nil {
-					errc <- err
-					return
-				}
-			}
-			if err := w.Flush(); err != nil {
-				// this error is triggered by topology.Stop
-				break
-			}
-		}
-		errc <- nil
-	}()
-
-	topology.Wait()
-	if err := topology.Error(); err != nil {
-		t.Fatalf("topology error: %v", err)
-	}
-	if err := <-errc; err != nil {
-		t.Fatalf("error from sending goroutine: %v", err)
-	}
-
-	out := topology.Output[0].(*outputtest.Recorder)
-	// we should have received something at least
-	if len(out.Records) == 0 {
-		t.Errorf("len(out.Lines) = 0, want to receive something")
-	}
-
-	if len(out.Records)%chunksz != 0 {
-		t.Errorf("len(out.Lines)= %d, want len(out.Lines)%%%d == 0, got %d", len(out.Records), chunksz, len(out.Records)%chunksz)
 	}
 }


### PR DESCRIPTION
#### :question: What

Fix some missing `Close` in `TCP` input and remove a flaky test. No need to fix it since this test (`TestTCPStopChunk`) only made sense if the closure semantics of the `TCP` input, once `TCP.Stop()` is called, was to wait for the currently bound connection, if any, to be closed by the client. But since this is not how  this input works, (i.e. it closes as soon as possible after receiving `Stop`) fixing the test to make it work would make it be the same as `TestTCPChunks`.

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
