### PR TITLE
fix: ExpandList behaviour if source is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TimestampRange filter accepts 'now' as range [#106](https://github.com/AdRoll/baker/pull/106)
 - Standardize the components' structs names [#105](https://github.com/AdRoll/baker/pull/105)
 - **Breaking** Change func FieldName to FieldNames (slice) as it allows to know the number of defined fields [#110](https://github.com/AdRoll/baker/pull/110)
-- ExpandList filter just forwards if the input list is empty. 
+- ExpandList filter just forwards if the input list is empty [#171](https://github.com/AdRoll/baker/pull/171)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TimestampRange filter accepts 'now' as range [#106](https://github.com/AdRoll/baker/pull/106)
 - Standardize the components' structs names [#105](https://github.com/AdRoll/baker/pull/105)
 - **Breaking** Change func FieldName to FieldNames (slice) as it allows to know the number of defined fields [#110](https://github.com/AdRoll/baker/pull/110)
-- ExpandList filter just forwards if the input list is empty [#171](https://github.com/AdRoll/baker/pull/171)
+- ExpandList filter just forwards if the source field is empty [#171](https://github.com/AdRoll/baker/pull/171)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TimestampRange filter accepts 'now' as range [#106](https://github.com/AdRoll/baker/pull/106)
 - Standardize the components' structs names [#105](https://github.com/AdRoll/baker/pull/105)
 - **Breaking** Change func FieldName to FieldNames (slice) as it allows to know the number of defined fields [#110](https://github.com/AdRoll/baker/pull/110)
+- ExpandList filter just forwards if the input list is empty. 
 
 ### Removed
 

--- a/filter/expand_list.go
+++ b/filter/expand_list.go
@@ -120,6 +120,8 @@ func (f *ExpandList) Process(l baker.Record, next func(baker.Record)) {
 
 	list := l.Get(f.source)
 	if len(list) == 0 {
+		// skip the empty string because bytes.Split
+		// transforms it to a slice with an empty string
 		next(l)
 		return
 	}

--- a/filter/expand_list.go
+++ b/filter/expand_list.go
@@ -119,6 +119,11 @@ func (f *ExpandList) Process(l baker.Record, next func(baker.Record)) {
 	atomic.AddInt64(&f.numProcessedLines, 1)
 
 	list := l.Get(f.source)
+	if len(list) == 0 {
+		next(l)
+		return
+	}
+
 	part := bytes.Split(list, f.sep)
 	for i, idx := range f.listIdx {
 		if idx >= len(part) {

--- a/filter/expand_list_test.go
+++ b/filter/expand_list_test.go
@@ -9,7 +9,7 @@ import (
 func TestExpandList(t *testing.T) {
 	tests := []struct {
 		name   string
-		record string // default: ",,"
+		record string
 
 		field  map[string]string
 		source string // default: "source"
@@ -149,9 +149,6 @@ func TestExpandList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.source == "" {
 				tt.source = "source"
-			}
-			if tt.record == "" {
-				tt.record = ",,"
 			}
 			cfg := baker.FilterParams{
 				ComponentParams: baker.ComponentParams{

--- a/filter/expand_list_test.go
+++ b/filter/expand_list_test.go
@@ -19,7 +19,7 @@ func TestExpandList(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:   "extract 2 value",
+			name:   "extract 2 values",
 			record: ",,value1;value2", // f1:"foo" f2:"bar" source:"value1;value2"
 			field: map[string]string{
 				"1": "f2",

--- a/filter/expand_list_test.go
+++ b/filter/expand_list_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestExpandList(t *testing.T) {
 	tests := []struct {
-		name string
-		list string
+		name   string
+		record string // default: ",,"
 
 		field  map[string]string
 		source string // default: "source"
@@ -19,20 +19,21 @@ func TestExpandList(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "extract 2 value",
-			list: "value1;value2",
+			name:   "extract 2 value",
+			record: ",,value1;value2", // f1:"foo" f2:"bar" source:"value1;value2"
 			field: map[string]string{
 				"1": "f2",
 				"0": "f1",
 			},
 			want: map[string]string{
-				"f1": "value1",
-				"f2": "value2",
+				"f1":     "value1",
+				"f2":     "value2",
+				"source": "value1;value2",
 			},
 		},
 		{
-			name: "extract 1 value",
-			list: "value1;value2",
+			name:   "extract 1 value",
+			record: ",,value1;value2",
 			field: map[string]string{
 				"32": "f1",
 				"1":  "f2",
@@ -43,8 +44,8 @@ func TestExpandList(t *testing.T) {
 			},
 		},
 		{
-			name: "sorce empty",
-			list: "",
+			name:   "sorce empty",
+			record: ",,",
 			field: map[string]string{
 				"1": "f2",
 			},
@@ -54,8 +55,21 @@ func TestExpandList(t *testing.T) {
 			},
 		},
 		{
-			name: "out of range",
-			list: "value1;value2",
+			name:   "only source is empty",
+			record: "foo,bar,",
+			field: map[string]string{
+				"0": "f1",
+				"1": "f2",
+			},
+			want: map[string]string{
+				"f1":     "foo",
+				"f2":     "bar",
+				"source": "",
+			},
+		},
+		{
+			name:   "out of range",
+			record: ",,value1;value2",
 			field: map[string]string{
 				"93": "f2",
 			},
@@ -65,8 +79,8 @@ func TestExpandList(t *testing.T) {
 			},
 		},
 		{
-			name: "change separator",
-			list: "value2-value1",
+			name:   "change separator",
+			record: ",,value2-value1",
 			field: map[string]string{
 				"0": "f2",
 				"1": "f1",
@@ -80,12 +94,12 @@ func TestExpandList(t *testing.T) {
 
 		// errors
 		{
-			name:    "Source not exists",
+			name:    "source not exists",
 			source:  "not_exist",
 			wantErr: true,
 		},
 		{
-			name: "Field name not exists",
+			name: "field name not exists",
 			field: map[string]string{
 				"0": "not_exist",
 			},
@@ -136,6 +150,9 @@ func TestExpandList(t *testing.T) {
 			if tt.source == "" {
 				tt.source = "source"
 			}
+			if tt.record == "" {
+				tt.record = ",,"
+			}
 			cfg := baker.FilterParams{
 				ComponentParams: baker.ComponentParams{
 					FieldByName: fieldByName,
@@ -156,11 +173,9 @@ func TestExpandList(t *testing.T) {
 			}
 
 			rec := &baker.LogLine{FieldSeparator: ','}
-			i, ok := fieldByName(tt.source)
-			if !ok {
-				t.Fatalf("uknown field %q", tt.source)
+			if err := rec.Parse([]byte(tt.record), nil); err != nil {
+				t.Fatalf("parse error %q: %v", tt.record, err)
 			}
-			rec.Set(i, []byte(tt.list))
 
 			filter.Process(rec, func(rec2 baker.Record) {
 				for k, v := range tt.want {


### PR DESCRIPTION
#### :question: What

The current implementation of the `ExpandList` filter has a strange behavior in the situation the input list is empty.
In particular the filter consider the empty list as a list with 1 empty elements, namely `""` -> `[""]`
 
For instance, consider the case in which the filter is configured to expand the list in the field `source` in such a way that `0 index` -> `f1` and `1 index` -> `f2`.

Thus, if we provide the following input record:
|f1|f2|source|
|--|---|---------|
|foo|bar||

The filter produces the corresponding output:
|f1|f2|source|
|--|---|---------|
||bar||

This PR changes the behavior of the filter and in the aforementioned situation it simply does nothing and forward. Thus, the output of the previous example will be:

|f1|f2|source|
|--|---|---------|
|foo|bar||


#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
