### PR TITLE
Clone configs instead of reusing pointer in desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Do not call Output.Stats() twice in `StatsDumper` [#173](https://github.com/AdRoll/baker/pull/173)
+- Call cloneConfig instead of resuing pointer in Desc configurations [#174](https://github.com/AdRoll/baker/pull/174)
 
 ### Security
 

--- a/config.go
+++ b/config.go
@@ -351,7 +351,7 @@ func NewConfigFromToml(f io.Reader, comp Components) (*Config, error) {
 	}
 
 	// Copy custom configuration structure, to prepare for re-reading
-	cfg.Input.DecodedConfig = cfg.Input.desc.Config
+	cfg.Input.DecodedConfig = cloneConfig(cfg.Input.desc.Config)
 	if err := decodeAndCheckConfig(md, cfg.Input); err != nil {
 		return nil, err
 	}
@@ -364,20 +364,20 @@ func NewConfigFromToml(f io.Reader, comp Components) (*Config, error) {
 		}
 	}
 
-	cfg.Output.DecodedConfig = cfg.Output.desc.Config
+	cfg.Output.DecodedConfig = cloneConfig(cfg.Output.desc.Config)
 	if err := decodeAndCheckConfig(md, cfg.Output); err != nil {
 		return nil, err
 	}
 
 	if cfg.Upload.Name != "" {
-		cfg.Upload.DecodedConfig = cfg.Upload.desc.Config
+		cfg.Upload.DecodedConfig = cloneConfig(cfg.Upload.desc.Config)
 		if err := decodeAndCheckConfig(md, cfg.Upload); err != nil {
 			return nil, err
 		}
 	}
 
 	if cfg.Metrics.Name != "" {
-		cfg.Metrics.DecodedConfig = cfg.Metrics.desc.Config
+		cfg.Metrics.DecodedConfig = cloneConfig(cfg.Metrics.desc.Config)
 		if err := decodeAndCheckConfig(md, cfg.Metrics); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
To trigger the problem fixed by this change you have to:
 - use a component with a Config structure using a map
 - somewhat manage to create, in the same process, at least 2 baker
 topologies using this component, each of which having different keys in
 the map.

Even if not impossible, it would be rather improbable to have this in a
normal production usage. However it's really easy to trigger with tests!

`go test -run foo` does exactly that`. It launches X times the tests
containing foo in their name, all in the same process.

The problem arises when copying the Desc.Config (an interface{}) to the
DecodedConfig field of the final component instance (also an
interface{}). The DecodedConfig is then used as destination for TOML
decoding.  But the thing is that the TOML library we're using merges
maps in TOML with the possibly existing content of the destination map
(which is probably a feature, really!). Since we've assigned an
interface onto another, we've actually just made the pointer part of the
destination interface (an interface is, under the hood, 2 fields, a type
and an interface) point to the pointer in the source interface.

In other words, we have decoded our TOML in the destination interface
DecodedConfig, but also in Desc.Config.

To solve this, it's enough to call cloneConfig in other words to create
new instances of the Config structs.

#### :question: What

Describe what this pull request does.

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
