### PR TITLE
input: kcl: add error to checkpointing error log

### DIFF
--- a/input/kcl.go
+++ b/input/kcl.go
@@ -343,7 +343,7 @@ func (p *recordProcessor) ProcessRecords(input *interfaces.ProcessRecordsInput) 
 	lastRecordSequenceNumber := input.Records[len(input.Records)-1].SequenceNumber
 	log.Debugf("Processed %d records: checkpoint=%s, msBehindLatest=%v", len(input.Records), aws.StringValue(lastRecordSequenceNumber), input.MillisBehindLatest)
 	if err := input.Checkpointer.Checkpoint(lastRecordSequenceNumber); err != nil {
-		log.Errorf("Error checkpointing at %s", *lastRecordSequenceNumber)
+		log.Errorf("Error checkpointing at %s: %s", *lastRecordSequenceNumber, err)
 	}
 }
 


### PR DESCRIPTION
When there's a checkpointing error, we were not logging the cause.