### PR TITLE
fix: force go get of the baker main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ git-update:
 setup: setup-git ## Setup Hugo locally 
 	npm install postcss-cli autoprefixer postcss
 
-gen-components: ## Generate components markdown from baker@latest
+gen-components: ## Generate components markdown from baker@main
 	cd utils/generate-components-pages && (go get github.com/AdRoll/baker@main; go generate)
 
 .PHONY: setup-git git-update setup gen-components

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ setup: setup-git ## Setup Hugo locally
 	npm install postcss-cli autoprefixer postcss
 
 gen-components: ## Generate components markdown from baker@latest
-	cd utils/generate-components-pages && (go get github.com/AdRoll/baker@latest; go generate)
+	cd utils/generate-components-pages && (go get github.com/AdRoll/baker@main; go generate)
 
 .PHONY: setup-git git-update setup gen-components
 


### PR DESCRIPTION
#### :question: What

Small fix on `gen-components` task: use `@main` instead of `@latest` in go get. Indeed, the `@latest` tag gets the latest release of the package instead of the latest version of the `main` branch. 