### PR TITLE
Require Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AdRoll/baker
 
-go 1.14
+go 1.16
 
 require (
 	github.com/DataDog/datadog-go v3.2.0+incompatible


### PR DESCRIPTION
zip_agnostic makes use of `io.NopCloser`, which is a 1.16 feature.

#### :question: What

Bumps Go version to 1.16 in go.mod

#### :hammer: How to test

Let the pipelines run unit tests (change done via the web GUI).

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [ ] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [ ] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [ ] Has `make gofmt-write` been run on the code?
- [ ] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [ ] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [ ] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
