### PR TITLE
Add count and tag filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the `Slice` filter [#175](https://github.com/AdRoll/baker/pull/175)
 - Clarify role of SQS.Bucket and add integration tests filter [#196](https://github.com/AdRoll/baker/pull/196)
 - Add filter_name tag to filtered_lines metric [#200](https://github.com/AdRoll/baker/pull/200)
+- Add CountAndTag filter [#201](https://github.com/AdRoll/baker/pull/201)
 
 ### Changed
 

--- a/filter/all.go
+++ b/filter/all.go
@@ -10,6 +10,7 @@ var All = []baker.FilterDesc{
 	ClauseFilterDesc,
 	ClearFieldsDesc,
 	ConcatenateDesc,
+	CountAndTagDesc,
 	CryptDesc,
 	DedupDesc,
 	ExpandJSONDesc,

--- a/filter/count_and_tag.go
+++ b/filter/count_and_tag.go
@@ -7,12 +7,10 @@ import (
 	"github.com/AdRoll/baker"
 )
 
-const countAndTagHelp = `Publish a metric that simply counts all records that pass through, using one of the field as value for metric tag.
+const countAndTagHelp = `Publish a metric that simply counts all records that pass through, and breaks them down, with metrics tags, by the value of a configured field.
+Records having an empty string as Field value are counted nonetheless, using the value configured as DefaultValue as tag value.
 
-By default, records having where the chosen field is empty are counted, but not tagged.
-You can change that behavior by setting a default tag value for these records, with the DefaultTagValue configuration parameter.
-
-NOTE: a special attention should be given in the selected Field used to tag records.
+NOTE: a special attention should be given in the selection of the Field used to tag records.
 For example, high-cardinality tags might cause performance degradation during tag ingestion/visualization, or even incur additional cost.
 As such, depending on the origin of the possible Field values, it might be worth filtering the data out.
 `
@@ -25,18 +23,17 @@ var CountAndTagDesc = baker.FilterDesc{
 }
 
 type CountAndTagConfig struct {
-	Metric          string `help:"Name of the metric, of type counter, this filter publishes" required:"true"`
-	Field           string `help:"Field to read to get tag values" required:"true"`
-	DefaultTagValue string `help:"Default value to use when Field is empty"`
+	Metric       string `help:"Name of the metric, of type counter, this filter publishes" required:"true"`
+	Field        string `help:"Field to read to get tag values" required:"true"`
+	DefaultValue string `help:"Default tag value under which records having empty Field are counted" required:"true"`
 }
 
 type CountAndTag struct {
-	metrics    baker.MetricsClient
-	fidx       baker.FieldIndex
-	fieldName  string
-	defValue   string
-	metricName string
-	tagKey     string
+	metrics     baker.MetricsClient
+	fidx        baker.FieldIndex
+	defaultTags []string // special case for default value
+	tagPrefix   []byte
+	metricName  string
 }
 
 func NewCountAndTag(cfg baker.FilterParams) (baker.Filter, error) {
@@ -47,13 +44,16 @@ func NewCountAndTag(cfg baker.FilterParams) (baker.Filter, error) {
 		return nil, fmt.Errorf("CountAndTag: unknown field %q", dcfg.Field)
 	}
 
+	// Do the most we can now, once, to avoid do it later, many times.
+	tagPrefix := strings.ToLower(dcfg.Field) + ":"
+	defaultTags := []string{tagPrefix + dcfg.DefaultValue}
+
 	f := &CountAndTag{
-		fidx:       fidx,
-		metricName: strings.ToLower(dcfg.Metric),
-		fieldName:  strings.ToLower(dcfg.Field),
-		tagKey:     strings.ToLower(dcfg.Field),
-		metrics:    cfg.Metrics,
-		defValue:   dcfg.DefaultTagValue,
+		fidx:        fidx,
+		metricName:  strings.ToLower(dcfg.Metric),
+		metrics:     cfg.Metrics,
+		tagPrefix:   []byte(tagPrefix),
+		defaultTags: defaultTags,
 	}
 	return f, nil
 }
@@ -65,15 +65,12 @@ func (f *CountAndTag) Stats() baker.FilterStats {
 func (f *CountAndTag) Process(l baker.Record, next func(baker.Record)) {
 	v := l.Get(f.fidx)
 	if len(v) == 0 {
-		if f.defValue == "" {
-			f.metrics.DeltaCount(f.metricName, 1)
-		} else {
-			// TODO: pre-concat the default key:value string (even the slice?)
-			f.metrics.DeltaCountWithTags(f.metricName, 1, []string{f.fieldName + ":" + f.defValue})
-		}
+		f.metrics.DeltaCountWithTags(f.metricName, 1, f.defaultTags)
 	} else {
-		// TODO: measure if necessary to use a strings.Builder here
-		f.metrics.DeltaCountWithTags(f.metricName, 1, []string{f.fieldName + ":" + string(v)})
+		tagkv := make([]byte, len(f.tagPrefix)+len(v))
+		n := copy(tagkv, f.tagPrefix)
+		copy(tagkv[n:], v)
+		f.metrics.DeltaCountWithTags(f.metricName, 1, []string{string(tagkv)})
 	}
 	next(l)
 }

--- a/filter/count_and_tag.go
+++ b/filter/count_and_tag.go
@@ -7,12 +7,17 @@ import (
 	"github.com/AdRoll/baker"
 )
 
-const countAndTagHelp = `Publish a metric that simply counts all records that pass through, and breaks them down, with metrics tags, by the value of a configured field.
-Records having an empty string as Field value are counted nonetheless, using the value configured as DefaultValue as tag value.
+const countAndTagHelp = `Publishes a metric that simply counts the number of records passing through, updating a metric of type counter.
+In addition, the metric is also tagged with the value of a given, configured, field.
+Records having an empty Field value are counted and tagged nonetheless, but they are tagged under the configured tag value: DefaultValue.
 
-NOTE: a special attention should be given in the selection of the Field used to tag records.
-For example, high-cardinality tags might cause performance degradation during tag ingestion/visualization, or even incur additional cost.
-As such, depending on the origin of the possible Field values, it might be worth filtering the data out.
+#### NOTE
+A special attention should be given to the Field used to tag records.
+For example, high-cardinality tags might cause performance degradation during tag ingestion and/or visualization and, depending on the metrics client you're using, could incur additional cost.
+Something else to keep in mind is that not all values might be valid for the metrics client/system you're using. This filter does not try in any way to validate those.
+
+Finally, it's good to keep in mind that metrics, like other means of observability (logs, tracing, etc.), are provided as best effort and should not influence the program outcome.
+As such, it's important to have strong guarantees about the set of possible values for the configured Field, or else it could be necessary to perform some filtering prior to place this filter in your pipeline.
 `
 
 var CountAndTagDesc = baker.FilterDesc{
@@ -23,9 +28,9 @@ var CountAndTagDesc = baker.FilterDesc{
 }
 
 type CountAndTagConfig struct {
-	Metric       string `help:"Name of the metric, of type counter, this filter publishes" required:"true"`
-	Field        string `help:"Field to read to get tag values" required:"true"`
-	DefaultValue string `help:"Default tag value under which records having empty Field are counted" required:"true"`
+	Metric       string `help:"Name of the metric of type counter published by this filter" required:"true"`
+	Field        string `help:"Field which value is used to to break down the metric by tag values" required:"true"`
+	DefaultValue string `help:"Default tag value to use when the value of the configured field is empty" required:"true"`
 }
 
 type CountAndTag struct {

--- a/filter/count_and_tag.go
+++ b/filter/count_and_tag.go
@@ -1,0 +1,79 @@
+package filter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AdRoll/baker"
+)
+
+const countAndTagHelp = `Publish a metric that simply counts all records that pass through, using one of the field as value for metric tag.
+
+By default, records having where the chosen field is empty are counted, but not tagged.
+You can change that behavior by setting a default tag value for these records, with the DefaultTagValue configuration parameter.
+
+NOTE: a special attention should be given in the selected Field used to tag records.
+For example, high-cardinality tags might cause performance degradation during tag ingestion/visualization, or even incur additional cost.
+As such, depending on the origin of the possible Field values, it might be worth filtering the data out.
+`
+
+var CountAndTagDesc = baker.FilterDesc{
+	Name:   "CountAndTag",
+	New:    NewCountAndTag,
+	Config: &CountAndTagConfig{},
+	Help:   countAndTagHelp,
+}
+
+type CountAndTagConfig struct {
+	Metric          string `help:"Name of the metric, of type counter, this filter publishes" required:"true"`
+	Field           string `help:"Field to read to get tag values" required:"true"`
+	DefaultTagValue string `help:"Default value to use when Field is empty"`
+}
+
+type CountAndTag struct {
+	metrics    baker.MetricsClient
+	fidx       baker.FieldIndex
+	fieldName  string
+	defValue   string
+	metricName string
+	tagKey     string
+}
+
+func NewCountAndTag(cfg baker.FilterParams) (baker.Filter, error) {
+	dcfg := cfg.DecodedConfig.(*CountAndTagConfig)
+
+	fidx, ok := cfg.FieldByName(dcfg.Field)
+	if !ok {
+		return nil, fmt.Errorf("CountAndTag: unknown field %q", dcfg.Field)
+	}
+
+	f := &CountAndTag{
+		fidx:       fidx,
+		metricName: strings.ToLower(dcfg.Metric),
+		fieldName:  strings.ToLower(dcfg.Field),
+		tagKey:     strings.ToLower(dcfg.Field),
+		metrics:    cfg.Metrics,
+		defValue:   dcfg.DefaultTagValue,
+	}
+	return f, nil
+}
+
+func (f *CountAndTag) Stats() baker.FilterStats {
+	return baker.FilterStats{}
+}
+
+func (f *CountAndTag) Process(l baker.Record, next func(baker.Record)) {
+	v := l.Get(f.fidx)
+	if len(v) == 0 {
+		if f.defValue == "" {
+			f.metrics.DeltaCount(f.metricName, 1)
+		} else {
+			// TODO: pre-concat the default key:value string (even the slice?)
+			f.metrics.DeltaCountWithTags(f.metricName, 1, []string{f.fieldName + ":" + f.defValue})
+		}
+	} else {
+		// TODO: measure if necessary to use a strings.Builder here
+		f.metrics.DeltaCountWithTags(f.metricName, 1, []string{f.fieldName + ":" + string(v)})
+	}
+	next(l)
+}

--- a/filter/count_and_tag_test.go
+++ b/filter/count_and_tag_test.go
@@ -20,7 +20,7 @@ func TestCountAndTag(t *testing.T) {
 		{
 			metric:      "some_metric",
 			field:       "field",
-			defTagValue: "",
+			defTagValue: "<some_default>",
 			fieldValues: []string{"foo", "bar", "baz", "foo"},
 			want: []string{
 				"delta|name=some_metric|value=1|tag=field:bar",
@@ -32,24 +32,24 @@ func TestCountAndTag(t *testing.T) {
 		{
 			metric:      "some_metric",
 			field:       "field",
-			defTagValue: "",
+			defTagValue: "<some_default>",
 			fieldValues: []string{"", "", "", "foo"},
 			want: []string{
-				"delta|name=some_metric|value=1",
-				"delta|name=some_metric|value=1",
-				"delta|name=some_metric|value=1",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
 				"delta|name=some_metric|value=1|tag=field:foo",
 			},
 		},
 		{
 			metric:      "some_metric",
 			field:       "field",
-			defTagValue: "<none>",
+			defTagValue: "<some_default>",
 			fieldValues: []string{"", "", "", "foo"},
 			want: []string{
-				"delta|name=some_metric|value=1|tag=field:<none>",
-				"delta|name=some_metric|value=1|tag=field:<none>",
-				"delta|name=some_metric|value=1|tag=field:<none>",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
+				"delta|name=some_metric|value=1|tag=field:<some_default>",
 				"delta|name=some_metric|value=1|tag=field:foo",
 			},
 		},
@@ -74,9 +74,9 @@ func TestCountAndTag(t *testing.T) {
 					},
 					Metrics: &metrics,
 					DecodedConfig: &CountAndTagConfig{
-						Metric:          tt.metric,
-						Field:           tt.field,
-						DefaultTagValue: tt.defTagValue,
+						Metric:       tt.metric,
+						Field:        tt.field,
+						DefaultValue: tt.defTagValue,
 					},
 				},
 			}

--- a/filter/count_and_tag_test.go
+++ b/filter/count_and_tag_test.go
@@ -57,23 +57,22 @@ func TestCountAndTag(t *testing.T) {
 		// error
 		{
 			metric:      "some_metric",
-			field:       "something",
+			field:       "something", // unknown field
 			defTagValue: "<none>",
 			fieldValues: []string{""},
 			wantError:   true,
 		},
 	}
 
-	// Only 'field' is a valid field value
-	fieldByName := func(name string) (baker.FieldIndex, bool) { return 0, name == "field" }
-
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
 			metrics := testutil.MockMetrics{}
 			params := baker.FilterParams{
 				ComponentParams: baker.ComponentParams{
-					FieldByName: fieldByName,
-					Metrics:     &metrics,
+					FieldByName: func(name string) (baker.FieldIndex, bool) {
+						return 0, name == "field" // Only 'field' exists
+					},
+					Metrics: &metrics,
 					DecodedConfig: &CountAndTagConfig{
 						Metric:          tt.metric,
 						Field:           tt.field,

--- a/filter/count_and_tag_test.go
+++ b/filter/count_and_tag_test.go
@@ -1,0 +1,107 @@
+package filter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/AdRoll/baker"
+	"github.com/AdRoll/baker/testutil"
+)
+
+func TestCountAndTag(t *testing.T) {
+	tests := []struct {
+		metric      string
+		field       string
+		defTagValue string
+		fieldValues []string // represent the value of 'field' in successive records (as many as len(fieldValues))
+		want        []string // list of lines returned by metrics client mock
+		wantError   bool
+	}{
+		{
+			metric:      "some_metric",
+			field:       "field",
+			defTagValue: "",
+			fieldValues: []string{"foo", "bar", "baz", "foo"},
+			want: []string{
+				"delta|name=some_metric|value=1|tag=field:bar",
+				"delta|name=some_metric|value=1|tag=field:baz",
+				"delta|name=some_metric|value=1|tag=field:foo",
+				"delta|name=some_metric|value=1|tag=field:foo",
+			},
+		},
+		{
+			metric:      "some_metric",
+			field:       "field",
+			defTagValue: "",
+			fieldValues: []string{"", "", "", "foo"},
+			want: []string{
+				"delta|name=some_metric|value=1",
+				"delta|name=some_metric|value=1",
+				"delta|name=some_metric|value=1",
+				"delta|name=some_metric|value=1|tag=field:foo",
+			},
+		},
+		{
+			metric:      "some_metric",
+			field:       "field",
+			defTagValue: "<none>",
+			fieldValues: []string{"", "", "", "foo"},
+			want: []string{
+				"delta|name=some_metric|value=1|tag=field:<none>",
+				"delta|name=some_metric|value=1|tag=field:<none>",
+				"delta|name=some_metric|value=1|tag=field:<none>",
+				"delta|name=some_metric|value=1|tag=field:foo",
+			},
+		},
+
+		// error
+		{
+			metric:      "some_metric",
+			field:       "something",
+			defTagValue: "<none>",
+			fieldValues: []string{""},
+			wantError:   true,
+		},
+	}
+
+	// Only 'field' is a valid field value
+	fieldByName := func(name string) (baker.FieldIndex, bool) { return 0, name == "field" }
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			metrics := testutil.MockMetrics{}
+			params := baker.FilterParams{
+				ComponentParams: baker.ComponentParams{
+					FieldByName: fieldByName,
+					Metrics:     &metrics,
+					DecodedConfig: &CountAndTagConfig{
+						Metric:          tt.metric,
+						Field:           tt.field,
+						DefaultTagValue: tt.defTagValue,
+					},
+				},
+			}
+
+			f, err := NewCountAndTag(params)
+			if err != nil {
+				if !tt.wantError {
+					t.Fatalf("got error: %v", err)
+				}
+				return
+			}
+
+			for _, val := range tt.fieldValues {
+				ll := baker.LogLine{}
+				if err := ll.Parse([]byte(val), nil); err != nil {
+					t.Fatal(err)
+				}
+				f.Process(&ll, func(baker.Record) {})
+			}
+
+			got := metrics.PublishedMetrics("")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("published metrics,\ngot:\n%+v\n\nwant:\n%v\n", got, tt.want)
+			}
+		})
+	}
+}

--- a/filter/external_match_test.go
+++ b/filter/external_match_test.go
@@ -309,7 +309,7 @@ func TestExternalMatchRefreshValues(t *testing.T) {
 	}
 
 	// Wait twice the amount of time after which the file should have been
-	// refreshed, to account for distrorted CPU time on shared CI machines.
+	// refreshed, to account for distorted CPU time on shared CI machines.
 	time.Sleep(2 * refreshEvery)
 
 	kept = false
@@ -317,6 +317,8 @@ func TestExternalMatchRefreshValues(t *testing.T) {
 	if kept {
 		t.Error("second call to Process() has kept the record, should have been discarded")
 	}
+	// Terminate the filter internal goroutine.
+	close(f.quit)
 }
 
 func pathToURI(p string) string {

--- a/testutil/mock_metrics.go
+++ b/testutil/mock_metrics.go
@@ -10,16 +10,17 @@ import (
 	"github.com/AdRoll/baker"
 )
 
-// MockMetricsDesc can be used in-lieu of actual metrics client for use in tests.
+// MockMetricsDesc describes the MockMetrics metrics client.
 var MockMetricsDesc = baker.MetricsDesc{
 	Name:   "MockMetrics",
 	Config: &struct{}{},
 	New:    newMockMetrics,
 }
 
-// MockMetrics is a metrics client that stores single calls made to the set of
-// methods implementing the baker.MetricsClient interface, and sort them so that
-// they're easy to compare mechanically, in tests.
+// MockMetrics is a metrics client to be used in tests only, which stores single
+// calls made to the set of methods implementing the baker.MetricsClient
+// interface, and sort them so that they're easy to compare mechanically, in
+// tests.
 type MockMetrics struct {
 	buf bytes.Buffer
 }

--- a/testutil/mock_metrics.go
+++ b/testutil/mock_metrics.go
@@ -1,0 +1,88 @@
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/AdRoll/baker"
+)
+
+// MockMetricsDesc can be used in-lieu of actual metrics client for use in tests.
+var MockMetricsDesc = baker.MetricsDesc{
+	Name:   "MockMetrics",
+	Config: &struct{}{},
+	New:    newMockMetrics,
+}
+
+// MockMetrics is a metrics client that stores single calls made to the set of
+// methods implementing the baker.MetricsClient interface, and sort them so that
+// they're easy to compare mechanically, in tests.
+type MockMetrics struct {
+	buf bytes.Buffer
+}
+
+func newMockMetrics(_ interface{}) (baker.MetricsClient, error) { return &MockMetrics{}, nil }
+
+// PublishedMetrics returns a list of strings, each of which represent arguments
+// and method of calls to methods of the baker.MetricsClient interface. Prefix
+// can be used to select a subset of calls, or all of them (with ""). Go runtime
+// metrics are ignored.
+func (m *MockMetrics) PublishedMetrics(prefix string) []string {
+	keep := make([]string, 0)
+	for _, s := range strings.Split(m.buf.String(), "\n") {
+		if len(strings.TrimSpace(s)) != 0 && !strings.Contains(s, "name=runtime.") {
+			if len(prefix) == 0 || strings.HasPrefix(s, prefix) {
+				keep = append(keep, s)
+			}
+		}
+	}
+
+	sort.Strings(keep)
+	return keep
+}
+
+func (m *MockMetrics) Gauge(name string, value float64) {
+	fmt.Fprintf(&m.buf, "gauge|name=%s|value=%v\n", name, value)
+}
+func (m *MockMetrics) RawCount(name string, value int64) {
+	fmt.Fprintf(&m.buf, "rawcount|name=%s|value=%v\n", name, value)
+}
+func (m *MockMetrics) DeltaCount(name string, delta int64) {
+	fmt.Fprintf(&m.buf, "delta|name=%s|value=%v\n", name, delta)
+}
+func (m *MockMetrics) Histogram(name string, value float64) {
+	fmt.Fprintf(&m.buf, "hist|name=%s|value=%v\n", name, value)
+}
+func (m *MockMetrics) Duration(name string, value time.Duration) {
+	fmt.Fprintf(&m.buf, "duration|name=%s|value=%v\n", name, value)
+}
+
+func (m *MockMetrics) GaugeWithTags(name string, value float64, tags []string) {
+	for _, t := range tags {
+		fmt.Fprintf(&m.buf, "gauge|name=%s|value=%v|tag=%s\n", name, value, t)
+	}
+}
+func (m *MockMetrics) RawCountWithTags(name string, value int64, tags []string) {
+	for _, t := range tags {
+		fmt.Fprintf(&m.buf, "rawcount|name=%s|value=%v|tag=%s\n", name, value, t)
+	}
+}
+func (m *MockMetrics) DeltaCountWithTags(name string, delta int64, tags []string) {
+	for _, t := range tags {
+		fmt.Fprintf(&m.buf, "delta|name=%s|value=%v|tag=%s\n", name, delta, t)
+	}
+}
+func (m *MockMetrics) HistogramWithTags(name string, value float64, tags []string) {
+	for _, t := range tags {
+		fmt.Fprintf(&m.buf, "hist|name=%s|value=%v|tag=%s\n", name, value, t)
+	}
+}
+func (m *MockMetrics) DurationWithTags(name string, value time.Duration, tags []string) {
+	for _, t := range tags {
+		fmt.Fprintf(&m.buf, "duration|name=%s|value=%v|tag=%s\n", name, value, t)
+	}
+}
+func (m *MockMetrics) Close() error { return nil }


### PR DESCRIPTION
#### :question: What

Add a new filter, called `CountAndTag`. This filter publishes a metric that simply counts all records that pass through, and breaks them down, with metrics tags, by the value of a configured field.
Records having an empty string as `Field` value are counted nonetheless, using the value configured as `DefaultValue` as tag value

note: performance has been measured on a real-life pipeline, with datadog as metrics client implementation, and both cpu and memory were dominated by io (reading from input, writing to output) so we consider the performance as acceptable, in fact it greatly depends on the metrics client implementation itself, since there will be one call per record, per filter chain process. That's not a problem per se since metrics libraries are optimized for this exact use case.

### Example visualization for a topology configured as follows:
```toml
[[filter]]
name = "CountAndTag"
[filter.config]
DefaultValue = "none"
Field = "currency"
Metric = "currency_name"
```

![image](https://user-images.githubusercontent.com/476650/164275392-2386dabb-3644-49dc-b22d-6f45b3057094.png)


While at it, fix a flaky windows test of the `ExternalMatch` filter.

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [x] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
