### PR TITLE
Filewriter/discard empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add filter_name tag to filtered_lines metric [#200](https://github.com/AdRoll/baker/pull/200)
 - Add CountAndTag filter [#201](https://github.com/AdRoll/baker/pull/201)
 - Add file size-based rotation for `FileWriter` output (`RotateSize` option) [#203](https://github.com/AdRoll/baker/pull/203)
+- Add `DiscardEmptyFiles` option to the `FileWriter` output [#204](https://github.com/AdRoll/baker/pull/204)
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.0
-	github.com/arl/dirtree v0.1.1
+	github.com/arl/dirtree v0.1.3
 	github.com/arl/zt v0.2.0
 	github.com/aws/aws-sdk-go v1.41.7
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b

--- a/go.sum
+++ b/go.sum
@@ -54,14 +54,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/arl/dirtree v0.0.0-20210810135648-71b3075f1a68 h1:1Igo9hHQvBFgOSDc9yJQNLIOWFLyhEt8Sggc9VwSt2w=
-github.com/arl/dirtree v0.0.0-20210810135648-71b3075f1a68/go.mod h1:uVPZKJm2M2hHWWUw+47yimVo48wNHtXEs19wwQOmy/U=
-github.com/arl/dirtree v0.1.0 h1:G8JDBYII8sjkBcNhjF5yeVQQYGlsAleoFoSW0ZQ7iqY=
-github.com/arl/dirtree v0.1.0/go.mod h1:uVPZKJm2M2hHWWUw+47yimVo48wNHtXEs19wwQOmy/U=
-github.com/arl/dirtree v0.1.1-0.20220429150511-59263fab3507 h1:Ht7RQeLWQLgFTvSZ7PmMAVh9KZXSr/0Cwf+ZXo9yZZw=
-github.com/arl/dirtree v0.1.1-0.20220429150511-59263fab3507/go.mod h1:uVPZKJm2M2hHWWUw+47yimVo48wNHtXEs19wwQOmy/U=
-github.com/arl/dirtree v0.1.1 h1:Oprikwhzr/kZHpjiXDH0MBkDJnaA7GnNIOiwog0HKfY=
-github.com/arl/dirtree v0.1.1/go.mod h1:uVPZKJm2M2hHWWUw+47yimVo48wNHtXEs19wwQOmy/U=
+github.com/arl/dirtree v0.1.3 h1:Q1ldIP0t4CQH3vUujlSgHEKwa6TqloXuxLNQRJHpl5w=
+github.com/arl/dirtree v0.1.3/go.mod h1:uVPZKJm2M2hHWWUw+47yimVo48wNHtXEs19wwQOmy/U=
 github.com/arl/zt v0.2.0 h1:DurTn8LtR23Vxuf8xso2d4N8bWfZTWSX/jCf3c78jTM=
 github.com/arl/zt v0.2.0/go.mod h1:+YG0QowKHuaKPT/NJfQodFzZH1VwIUXf4CtgvnrWEeA=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/output/filewriter.go
+++ b/output/filewriter.go
@@ -255,7 +255,7 @@ func newWorker(cfg *FileWriterConfig, tmpl *template.Template, replFieldValue st
 		uid:            uid,
 		rotateIdx:      0,
 		useZstd:        strings.HasSuffix(cfg.PathString, ".zst") || strings.HasSuffix(cfg.PathString, ".zstd"),
-		writtenOnce:    true,
+		writtenOnce:    false,
 	}
 
 	curPath, err := fw.makePath(tmpl)
@@ -266,8 +266,6 @@ func newWorker(cfg *FileWriterConfig, tmpl *template.Template, replFieldValue st
 	if err != nil {
 		return nil, fmt.Errorf("can't create file: %v", err)
 	}
-
-	// Flag used to decide whether discarding empty files.
 
 	// Perform rotation. Close, upload and swap curw with a newly
 	// created file, after evaluating the path template.

--- a/output/filewriter_test.go
+++ b/output/filewriter_test.go
@@ -214,8 +214,6 @@ func testFileWriterCompareInOut(numRecords int, wait, rotate time.Duration, comp
 }
 
 func TestFileWriterCompareInOut(t *testing.T) {
-	t.Parallel()
-
 	defer testutil.DisableLogging()()
 
 	tests := []struct {
@@ -670,7 +668,7 @@ func TestFileWriterDiscardEmptyFiles(t *testing.T) {
 		procs = 1
 		[output.config]
 		pathstring = %q
-		rotateInterval = "50ms"
+		rotateInterval = "150ms"
 		discardEmptyFiles = true
 	`
 	if !testing.Verbose() {

--- a/output/filewriter_test.go
+++ b/output/filewriter_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/arl/dirtree"
 	"github.com/arl/zt"
-	zstd "github.com/valyala/gozstd"
 
 	"github.com/AdRoll/baker"
 	"github.com/AdRoll/baker/input"
@@ -529,6 +528,26 @@ func decompressFilesInDir(tb testing.TB, root string) []string {
 	return decompressed
 }
 
+// countLines returns the number of lines in a file, either compressed (zstd/gz)
+// or uncompressed.
+func countLines(r io.Reader) (int, error) {
+	zr, err := zt.NewReader(r)
+	if err != nil {
+		return 0, fmt.Errorf("countLines: %w", err)
+	}
+	defer zr.Close()
+
+	nlines := 0
+	scan := bufio.NewScanner(zr)
+	for scan.Scan() {
+		nlines++
+	}
+	if scan.Err() != nil {
+		return nlines, fmt.Errorf("countLines: %w", scan.Err())
+	}
+	return nlines, nil
+}
+
 // inputCSV contains 2000 CSV lines.
 // Data in the following file has been generated from
 // https://www.convertcsv.com/generate-test-data.htm with the following
@@ -619,18 +638,90 @@ func TestFileWriterRotateSize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		zr := zstd.NewReader(f)
-		scan := bufio.NewScanner(zr)
-		for scan.Scan() {
-			nlines++
-		}
-		if scan.Err() != nil {
+		n, err := countLines(f)
+		if err != nil {
 			t.Fatal(err)
 		}
-		zr.Release()
+		nlines += n
 		f.Close()
 	}
 	if nlines != bakerDataCount*inputCSVNumLines {
 		t.Errorf("total lines = %d, want %d", nlines, bakerDataCount*inputCSVNumLines)
+	}
+}
+
+func TestFileWriterDiscardEmptyFiles(t *testing.T) {
+	defer testutil.DisableLogging()()
+
+	tmpDir := t.TempDir()
+	toml := `
+		[csv]
+		field_separator=","
+
+		[fields]
+		names = ["kind", "digits", "first", "last", "email", "state"]
+
+		[input]
+		name = "channel"
+
+		[output]
+		fields = []
+		name = "filewriter"
+		procs = 1
+		[output.config]
+		pathstring = %q
+		rotateInterval = "50ms"
+		discardEmptyFiles = true
+	`
+	if !testing.Verbose() {
+		defer testutil.LessLogging()()
+	}
+
+	toml = fmt.Sprintf(toml, filepath.Join(tmpDir, "file-{{.Hour}}-{{.Minute}}-{{.Second}}.log.gz"))
+	cfg, err := baker.NewConfigFromToml(strings.NewReader(toml),
+		baker.Components{
+			Inputs:  []baker.InputDesc{inputtest.ChannelDesc},
+			Outputs: []baker.OutputDesc{output.FileWriterDesc},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	topo, err := baker.NewTopologyFromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := topo.Input.(*inputtest.Channel)
+	go func() {
+		*in <- baker.Data{Bytes: []byte(";;;;\n")}
+		time.Sleep(time.Second)
+		close(*in)
+	}()
+
+	topo.Start()
+	topo.Wait()
+
+	files, err := dirtree.List(tmpDir, dirtree.Type("f"), dirtree.ModeAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("got %d files, want one and only one file", len(files))
+	}
+
+	f, err := os.Open(files[0].Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	n, err := countLines(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n != 1 {
+		t.Fatalf("got %d lines in %q, want a single line", n, files[0].Path)
 	}
 }


### PR DESCRIPTION
#### :question: What

Add `DiscardEmptyFiles` option to `FileWriter` output.

When `RotateInterval` is set (i.e. the worker creates a new file at a given frequency), by default, the new file is always created no matter what, even if the file is empty because no log lines have been received by the output yet.
Setting `DiscardEmptyFiles` to true changes that behaviour. When that happens, the empty file won't be rotated and further writes will be made on the same file.

#### :hammer: How to test

1. List all steps necessary;
2. To test this pull request.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [x] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [x] Have the changes in this PR been functionally tested?
- [ ] Have new components been added to the related `all.go` files?
- [ ] Have new components been added to the documentation website?
- [x] Has `make gofmt-write` been run on the code?
- [x] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [x] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [x] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
