### PR TITLE
Implementing a new config QueueNames to sqs Input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add file size-based rotation for `FileWriter` output (`RotateSize` option) [#203](https://github.com/AdRoll/baker/pull/203)
 - Add `DiscardEmptyFiles` option to the `FileWriter` output [#204](https://github.com/AdRoll/baker/pull/204)
 - Add `URLEscape` and `URLParam` filters [#206](https://github.com/AdRoll/baker/pull/206)
+- Add `QueueNames` parameter to SQS Input [#210](https://github.com/AdRoll/baker/pull/210)
 
 ### Changed
 

--- a/input/sqs.go
+++ b/input/sqs.go
@@ -41,7 +41,8 @@ Supported formats (MessageFormat):
 type SQSConfig struct {
 	AwsRegion         string   `help:"AWS region to connect to" default:"us-west-2"`
 	Bucket            string   `help:"S3 Bucket to use if paths do not have one" default:""`
-	QueuePrefixes     []string `help:"Prefixes of the names of the SQS queues to monitor" required:"true"`
+	QueuePrefixes     []string `help:"Prefixes of the names of the SQS queues to monitor" required:"true" if QueueNames not set`
+	QueueNames        []string `help:"Names of the SQS queues to monitor" required:"true" if QueuePrefixes not set`
 	MessageFormat     string   `help:"SQS message format. See help string for supported formats" default:"sns"`
 	MessageExpression string   `help:"The expression to extract an S3 path from arbitrary message formats"`
 	FilePathFilter    string   `help:"If provided, will only use S3 files with the given path."`
@@ -107,6 +108,9 @@ func NewSQS(cfg baker.InputParams) (baker.Input, error) {
 		if filepathRx, err = regexp.Compile(dcfg.FilePathFilter); err != nil {
 			return nil, fmt.Errorf("SQS: can't compile FilePathFilter: %v", err)
 		}
+	}
+	if len(dcfg.QueuePrefixes) == 0 && len(dcfg.QueueNames) {
+		return nil, fmt.Errorf("SQS: QueuePrefixes or QueueNames must be set")
 	}
 
 	sess, err := session.NewSession(&aws.Config{Region: aws.String(dcfg.AwsRegion)})
@@ -246,7 +250,17 @@ func (s *SQS) Run(inch chan<- *baker.Data) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var wg sync.WaitGroup
+	queueUrls := []string{}
+
+	for _, queueName := range s.Cfg.QueueNames {
+
+		resp, err := s.svc.GetQueueUrlWithContext(ctx, &sqs.GetQueueUrlInput{})
+		if err != nil {
+			return err
+		}
+		queueUrls = append(queueUrls, resp.QueueUrl)
+	}
+
 	for _, prefix := range s.Cfg.QueuePrefixes {
 
 		resp, err := s.svc.ListQueuesWithContext(ctx, &sqs.ListQueuesInput{
@@ -256,14 +270,17 @@ func (s *SQS) Run(inch chan<- *baker.Data) error {
 			return err
 		}
 
-		for _, url := range resp.QueueUrls {
-			wg.Add(1)
-			go func(url string) {
-				defer wg.Done()
+		queueUrls = append(queueUrls, resp.QueueUrls)
+	}
 
-				s.pollQueue(ctx, url)
-			}(*url)
-		}
+	var wg sync.WaitGroup
+	for _, url := range queueUrls {
+		wg.Add(1)
+		go func(url string) {
+			defer wg.Done()
+
+			s.pollQueue(ctx, url)
+		}(*url)
 	}
 
 	// The correct order of operation to cleanly stop the whole pipeline is the

--- a/input/sqs.go
+++ b/input/sqs.go
@@ -254,7 +254,9 @@ func (s *SQS) Run(inch chan<- *baker.Data) error {
 
 	for _, queueName := range s.Cfg.QueueNames {
 
-		resp, err := s.svc.GetQueueUrlWithContext(ctx, &sqs.GetQueueUrlInput{})
+		resp, err := s.svc.GetQueueUrlWithContext(ctx, &sqs.GetQueueUrlInput{
+			QueueName: aws.String(queueName),
+		})
 		if err != nil {
 			return err
 		}

--- a/input/sqs_test.go
+++ b/input/sqs_test.go
@@ -27,16 +27,19 @@ import (
 func TestSQSParseMessage(t *testing.T) {
 	tests := []struct {
 		name                        string
+		queues                      []string
 		format, message, expression string
 		wantPath                    string
 		wantConfigErr, wantParseErr bool
 	}{
 		{
+			queues:   []string{"some-queue"},
 			format:   "plain",
 			message:  "s3://some-bucket/with/stuff/inside",
 			wantPath: "s3://some-bucket/with/stuff/inside",
 		},
 		{
+			queues: []string{"some-queue"},
 			format: "sns",
 			message: `
 			{
@@ -47,6 +50,7 @@ func TestSQSParseMessage(t *testing.T) {
 			wantPath: "s3://another-bucket/path/to/file",
 		},
 		{
+			queues:     []string{"some-queue"},
 			format:     "json",
 			expression: "Foo.Bar",
 			message: `
@@ -59,6 +63,7 @@ func TestSQSParseMessage(t *testing.T) {
 			wantPath: "s3://another-bucket/path/to/file",
 		},
 		{
+			queues:     []string{"some-queue"},
 			format:     "s3::ObjectCreated",
 			expression: "Records[*].join('/',['s3:/', s3.bucket.name, s3.object.key]) | [0]",
 			message: `
@@ -103,6 +108,7 @@ func TestSQSParseMessage(t *testing.T) {
 			wantPath: "s3://mybucket/path/to/a/csv/file/in/a/bucket/file.csv.log.zst",
 		},
 		{
+			queues:     []string{"some-queue"},
 			format:     "json",
 			expression: "Records[*].join('/',['s3:/', s3.bucket.name, s3.object.key]) | [0]",
 			message: `
@@ -170,9 +176,17 @@ func TestSQSParseMessage(t *testing.T) {
 			wantPath:      "whatever",
 			wantConfigErr: true,
 		},
+		{
+			queues:        []string{},
+			format:        "plain",
+			message:       "s3://some-bucket/with/stuff/inside",
+			wantPath:      "s3://some-bucket/with/stuff/inside",
+			wantConfigErr: true,
+		},
 
 		// parse errors
 		{
+			queues:     []string{"some-queue"},
 			name:       "invalid json payload",
 			format:     "json",
 			expression: "Foo.Bar",
@@ -186,6 +200,7 @@ func TestSQSParseMessage(t *testing.T) {
 			wantParseErr: true,
 		},
 		{
+			queues:     []string{"some-queue"},
 			name:       "field not found",
 			format:     "json",
 			expression: "Foo.Bar",
@@ -197,6 +212,7 @@ func TestSQSParseMessage(t *testing.T) {
 			wantParseErr: true,
 		},
 		{
+			queues:     []string{"some-queue"},
 			name:       "field of wrong type",
 			format:     "json",
 			expression: "Foo.Bar",
@@ -220,6 +236,7 @@ func TestSQSParseMessage(t *testing.T) {
 			in, err := NewSQS(baker.InputParams{
 				ComponentParams: baker.ComponentParams{
 					DecodedConfig: &SQSConfig{
+						QueueNames:        tt.queues,
 						MessageFormat:     string(tt.format),
 						MessageExpression: tt.expression,
 					},
@@ -252,6 +269,7 @@ type sqsIntegrationTestCase struct {
 
 	// SQS input configuration
 	queuePrefixes []string // QueuePrefixes configuration parameter
+	queueNames    []string // QueueNames configuration parameter
 	bucket        string   // Bucket configuration parameter
 
 	// SQS service configuration
@@ -312,6 +330,21 @@ func TestSQS(t *testing.T) {
 				"bucket-a,path/to,2.zst",
 			},
 		},
+		{
+			name:       "use provided bucket",
+			queueNames: []string{"queue-a"},
+			bucket:     "bucket-a",
+			messages: map[string][]sqs.Message{
+				"queue-a": {
+					sqsMessage("path/to/file/1.zst"),
+					sqsMessage("path/to/file/2.zst"),
+				},
+			},
+			wantRecords: []string{
+				"bucket-a,path/to,1.zst",
+				"bucket-a,path/to,2.zst",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,6 +367,7 @@ Name="sqs"
 Bucket=%q
 MessageFormat="plain"
 QueuePrefixes=[%v]
+QueueNames=[%v]
 FilePathFilter=".*"
 
 [output]
@@ -352,8 +386,12 @@ fields=["bucket", "path", "filename"]
 		for _, pref := range tc.queuePrefixes {
 			prefixes = append(prefixes, `"`+pref+`"`)
 		}
+		queues := []string{}
+		for _, name := range tc.queueNames {
+			queues = append(queues, `"`+name+`"`)
+		}
 
-		r := strings.NewReader(fmt.Sprintf(toml, tc.bucket, strings.Join(prefixes, ",")))
+		r := strings.NewReader(fmt.Sprintf(toml, tc.bucket, strings.Join(prefixes, ","), strings.Join(queues, ",")))
 		cfg, err := baker.NewConfigFromToml(r, comp)
 		if err != nil {
 			t.Fatal(err)
@@ -432,13 +470,13 @@ func (c *mockSQSClient) GetQueueUrlWithContext(ctx aws.Context, input *sqs.GetQu
 
 	queueName := ""
 	for name := range c.queues {
-		if name == *input.queueName {
+		if name == *input.QueueName {
 			queueName = "https://sqs.us-west-2.amazonaws.com/123456789012/" + name
 			break
 		}
 	}
 
-	out := &sqs.GetQueueUrlOutput{QueueUrl: queueName}
+	out := &sqs.GetQueueUrlOutput{QueueUrl: &queueName}
 	log.WithFields(log.Fields{"sqs": "GetQueueUrlWithContext", "input": *input, "out": *out}).Debug()
 	return out, nil
 }

--- a/input/sqs_test.go
+++ b/input/sqs_test.go
@@ -426,6 +426,23 @@ func (c *mockSQSClient) ListQueuesWithContext(ctx aws.Context, input *sqs.ListQu
 	return out, nil
 }
 
+func (c *mockSQSClient) GetQueueUrlWithContext(ctx aws.Context, input *sqs.GetQueueUrlInput, options ...request.Option) (*sqs.GetQueueUrlOutput, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	queueName := ""
+	for name := range c.queues {
+		if name == *input.queueName {
+			queueName = "https://sqs.us-west-2.amazonaws.com/123456789012/" + name
+			break
+		}
+	}
+
+	out := &sqs.GetQueueUrlOutput{QueueUrl: queueName}
+	log.WithFields(log.Fields{"sqs": "GetQueueUrlWithContext", "input": *input, "out": *out}).Debug()
+	return out, nil
+}
+
 // ReceiveMessageWithContext sends the first message for the requested queue, if
 // any, then removes it from the queue.
 func (c *mockSQSClient) ReceiveMessageWithContext(ctx aws.Context, input *sqs.ReceiveMessageInput, options ...request.Option) (*sqs.ReceiveMessageOutput, error) {


### PR DESCRIPTION
Queue prefixes could lead to undesired behaviour, this new option makes the use strict to specific queues

#### :question: What

Implementing a new config QueueNames to sqs Input. 
When using deadletter queues in SQS we often do not expect Baker to read from that queue, but because the default is to add the suffix to the queue name to indicate is a dead-letter queue, Baker ends up reading from that queue too.

With this new parameter we are strict to which queues we want to read from without surprises if some queue with similar name is created.

#### :hammer: How to test

Change the QueuePrefixes parameter to QueueNames - it should behave the same way, but it will listen only to that specific queue.

#### :white_check_mark: Checklists

_This section contains a list of checklists for common uses, please delete the checklists that are useless for your current use case (or add another checklist if your use case isn't covered yet)._

- [X] Is there unit/integration test coverage for all new and/or changed functionality added in this PR?
- [X] Have the changes in this PR been functionally tested?
- [X] Have new components been added to the related `all.go` files?
- [X] Have new components been added to the documentation website?
- [X] Has `make gofmt-write` been run on the code?
- [X] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [X] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
- [X] Have the steps in [CONTRIBUTING.md](./CONTRIBUTING.md) been followed to update a Go module?
