### PR TITLE
Creates a new flagset to avoid conflit with other libraries that use the same flag

### DIFF
--- a/baker_cli.go
+++ b/baker_cli.go
@@ -30,6 +30,8 @@ func MainCLI(components Components) error {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stderr)
 
+	// Create a new flagset to avoid conflict with other libraries
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	var (
 		flagHelpConfig = flag.String("help", "", "show help for a `component` (input/filter/output/upload) (use '*' to dump all)")
 		flagVerbose    = flag.Bool("v", false, "verbose logging (debug level)")


### PR DESCRIPTION
…the same flag

https://github.com/DataDog/dd-trace-go/issues/1153

#### :question: What

Baker library conflicts with dd-trace-go library because of dependencies on glog.
glog also defines the flag v
`panic: /var/folders/yg/7bk34drs0zjfsb9b_r_1sykr0000gn/T/go-build2940344100/b001/exe/main flag redefined: v
`

This PR make possible to use both libraries side by side.
It's not possible to send PR to glog because it's a Google internal library that does not accept contributions. But dd-trace-go and also [ristretto](https://github.com/SemanticSugar/baker/blob/main/go.mod#L11) have dependencies on it. 

#### :hammer: How to reproduce the error

Try to import both libraries at the same time:

```
package main

import (
	"fmt"

	"github.com/AdRoll/baker"
	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
)
func main() {
	tracer.Start(
		tracer.WithEnv("testing"),
		tracer.WithService("tags-automation"),
	)
	defer tracer.Stop()
	components := baker.Components{}
	if err := baker.MainCLI(components); err != nil {
		fmt.Println(err.Error())
	}
}
```

produces the error:
```
panic: /var/folders/yn/hdtb3wnd5xg31ygy3vt2g99w0000gn/T/go-build2429850215/b001/exe/testing flag redefined: v

goroutine 1 [running]:
flag.(*FlagSet).Var(0x140000bc120, {0x1059befb8, 0x140004814a8}, {0x1053ac54c, 0x1}, {0x10540798b, 0x1d})
        /usr/local/go/src/flag/flag.go:980 +0x2a4
flag.(*FlagSet).BoolVar(...)
        /usr/local/go/src/flag/flag.go:715
flag.(*FlagSet).Bool(0x0?, {0x1053ac54c, 0x1}, 0x0, {0x10540798b, 0x1d})
        /usr/local/go/src/flag/flag.go:728 +0x70
flag.Bool(...)
        /usr/local/go/src/flag/flag.go:735
github.com/AdRoll/baker.MainCLI({{0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
        /Users/danimar.ribeiro/go/pkg/mod/github.com/!ad!roll/baker@v0.1.0-alpha/baker_cli.go:35 +0xec
main.main()
        /Users/danimar.ribeiro/Projetos/extra/baker-test/testing.go:17 +0xb4
exit status 2
```

#### :white_check_mark: Checklists


- [X] Have the changes in this PR been functionally tested?
- [X] Has `make gofmt-write` been run on the code?
- [X] Has `make govet` been run on the code? Has the code been fixed accordingly to the output?
- [X] Have the changes been added to the [CHANGELOG.md](./CHANGELOG.md) file?
